### PR TITLE
fix(docs)!: published reference pointed integrators at DEV servers + channel-manager from build output

### DIFF
--- a/schemas/booking-engine.json
+++ b/schemas/booking-engine.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Use the Lookup API to help find the destination where you will be searching for available travel inventory.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#booking-engine/tag/lookup"
+        "url": "https://api.wink.travel/scalar#booking-engine/tag/lookup"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Find properties and ancillaries by identifier, country, city, lookup, map bounds and more.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#booking-engine/tag/inventory"
+        "url": "https://api.wink.travel/scalar#booking-engine/tag/inventory"
       }
     },
     {
@@ -46,7 +46,7 @@
       "description": "Manages interaction with TripPay pre-payment.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#booking-engine/tag/checkout"
+        "url": "https://api.wink.travel/scalar#booking-engine/tag/checkout"
       }
     },
     {
@@ -54,7 +54,7 @@
       "description": "Manages shopping cart state for Wink users.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#booking-engine/tag/shopping-cart"
+        "url": "https://api.wink.travel/scalar#booking-engine/tag/shopping-cart"
       }
     },
     {
@@ -62,7 +62,7 @@
       "description": "Loads up a customization client with enough information to load up the booking engine.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#booking-engine/tag/customization-client"
+        "url": "https://api.wink.travel/scalar#booking-engine/tag/customization-client"
       }
     }
   ],
@@ -2952,11 +2952,11 @@
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "userSpecifiedCurrencyAveragePricePerNight": {
+                            "internalAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "internalAveragePricePerNight": {
+                            "userSpecifiedCurrencyAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
@@ -3157,8 +3157,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 },
                                 "address": {
                                   "address1": "234 Near da beach",
@@ -3168,8 +3168,8 @@
                                   "county": "Alameda county",
                                   "city": "Bangkok",
                                   "countryCode": "TH",
-                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                  "country": "United States"
+                                  "country": "United States",
+                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                 },
                                 "commissionable": true,
                                 "name": "Archery lesson",
@@ -3597,8 +3597,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -3608,8 +3608,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -3872,11 +3872,11 @@
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "userSpecifiedCurrencyAveragePricePerNight": {
+                              "internalAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "internalAveragePricePerNight": {
+                              "userSpecifiedCurrencyAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
@@ -4077,8 +4077,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   },
                                   "address": {
                                     "address1": "234 Near da beach",
@@ -4088,8 +4088,8 @@
                                     "county": "Alameda county",
                                     "city": "Bangkok",
                                     "countryCode": "TH",
-                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                    "country": "United States"
+                                    "country": "United States",
+                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                   },
                                   "commissionable": true,
                                   "name": "Archery lesson",
@@ -4976,11 +4976,11 @@
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "userSpecifiedCurrencyAveragePricePerNight": {
+                            "internalAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "internalAveragePricePerNight": {
+                            "userSpecifiedCurrencyAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
@@ -5181,8 +5181,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 },
                                 "address": {
                                   "address1": "234 Near da beach",
@@ -5192,8 +5192,8 @@
                                   "county": "Alameda county",
                                   "city": "Bangkok",
                                   "countryCode": "TH",
-                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                  "country": "United States"
+                                  "country": "United States",
+                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                 },
                                 "commissionable": true,
                                 "name": "Archery lesson",
@@ -5621,8 +5621,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -5632,8 +5632,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -5896,11 +5896,11 @@
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "userSpecifiedCurrencyAveragePricePerNight": {
+                              "internalAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "internalAveragePricePerNight": {
+                              "userSpecifiedCurrencyAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
@@ -6101,8 +6101,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   },
                                   "address": {
                                     "address1": "234 Near da beach",
@@ -6112,8 +6112,8 @@
                                     "county": "Alameda county",
                                     "city": "Bangkok",
                                     "countryCode": "TH",
-                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                    "country": "United States"
+                                    "country": "United States",
+                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                   },
                                   "commissionable": true,
                                   "name": "Archery lesson",
@@ -7000,11 +7000,11 @@
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "userSpecifiedCurrencyAveragePricePerNight": {
+                            "internalAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "internalAveragePricePerNight": {
+                            "userSpecifiedCurrencyAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
@@ -7205,8 +7205,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 },
                                 "address": {
                                   "address1": "234 Near da beach",
@@ -7216,8 +7216,8 @@
                                   "county": "Alameda county",
                                   "city": "Bangkok",
                                   "countryCode": "TH",
-                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                  "country": "United States"
+                                  "country": "United States",
+                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                 },
                                 "commissionable": true,
                                 "name": "Archery lesson",
@@ -7645,8 +7645,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7656,8 +7656,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -7920,11 +7920,11 @@
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "userSpecifiedCurrencyAveragePricePerNight": {
+                              "internalAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "internalAveragePricePerNight": {
+                              "userSpecifiedCurrencyAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
@@ -8125,8 +8125,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   },
                                   "address": {
                                     "address1": "234 Near da beach",
@@ -8136,8 +8136,8 @@
                                     "county": "Alameda county",
                                     "city": "Bangkok",
                                     "countryCode": "TH",
-                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                    "country": "United States"
+                                    "country": "United States",
+                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                   },
                                   "commissionable": true,
                                   "name": "Archery lesson",
@@ -9024,11 +9024,11 @@
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "userSpecifiedCurrencyAveragePricePerNight": {
+                            "internalAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "internalAveragePricePerNight": {
+                            "userSpecifiedCurrencyAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
@@ -9229,8 +9229,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 },
                                 "address": {
                                   "address1": "234 Near da beach",
@@ -9240,8 +9240,8 @@
                                   "county": "Alameda county",
                                   "city": "Bangkok",
                                   "countryCode": "TH",
-                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                  "country": "United States"
+                                  "country": "United States",
+                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                 },
                                 "commissionable": true,
                                 "name": "Archery lesson",
@@ -9669,8 +9669,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -9680,8 +9680,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -9944,11 +9944,11 @@
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "userSpecifiedCurrencyAveragePricePerNight": {
+                              "internalAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "internalAveragePricePerNight": {
+                              "userSpecifiedCurrencyAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
@@ -10149,8 +10149,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   },
                                   "address": {
                                     "address1": "234 Near da beach",
@@ -10160,8 +10160,8 @@
                                     "county": "Alameda county",
                                     "city": "Bangkok",
                                     "countryCode": "TH",
-                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                    "country": "United States"
+                                    "country": "United States",
+                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                   },
                                   "commissionable": true,
                                   "name": "Archery lesson",
@@ -11048,11 +11048,11 @@
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "userSpecifiedCurrencyAveragePricePerNight": {
+                            "internalAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "internalAveragePricePerNight": {
+                            "userSpecifiedCurrencyAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
@@ -11253,8 +11253,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 },
                                 "address": {
                                   "address1": "234 Near da beach",
@@ -11264,8 +11264,8 @@
                                   "county": "Alameda county",
                                   "city": "Bangkok",
                                   "countryCode": "TH",
-                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                  "country": "United States"
+                                  "country": "United States",
+                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                 },
                                 "commissionable": true,
                                 "name": "Archery lesson",
@@ -11693,8 +11693,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -11704,8 +11704,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -11968,11 +11968,11 @@
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "userSpecifiedCurrencyAveragePricePerNight": {
+                              "internalAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "internalAveragePricePerNight": {
+                              "userSpecifiedCurrencyAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
@@ -12173,8 +12173,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   },
                                   "address": {
                                     "address1": "234 Near da beach",
@@ -12184,8 +12184,8 @@
                                     "county": "Alameda county",
                                     "city": "Bangkok",
                                     "countryCode": "TH",
-                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                    "country": "United States"
+                                    "country": "United States",
+                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                   },
                                   "commissionable": true,
                                   "name": "Archery lesson",
@@ -13072,11 +13072,11 @@
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "userSpecifiedCurrencyAveragePricePerNight": {
+                            "internalAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
-                            "internalAveragePricePerNight": {
+                            "userSpecifiedCurrencyAveragePricePerNight": {
                               "amount": 1250,
                               "currency": "USD"
                             },
@@ -13277,8 +13277,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 },
                                 "address": {
                                   "address1": "234 Near da beach",
@@ -13288,8 +13288,8 @@
                                   "county": "Alameda county",
                                   "city": "Bangkok",
                                   "countryCode": "TH",
-                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                  "country": "United States"
+                                  "country": "United States",
+                                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                 },
                                 "commissionable": true,
                                 "name": "Archery lesson",
@@ -13717,8 +13717,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -13728,8 +13728,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -13992,11 +13992,11 @@
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "userSpecifiedCurrencyAveragePricePerNight": {
+                              "internalAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
-                              "internalAveragePricePerNight": {
+                              "userSpecifiedCurrencyAveragePricePerNight": {
                                 "amount": 1250,
                                 "currency": "USD"
                               },
@@ -14197,8 +14197,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   },
                                   "address": {
                                     "address1": "234 Near da beach",
@@ -14208,8 +14208,8 @@
                                     "county": "Alameda county",
                                     "city": "Bangkok",
                                     "countryCode": "TH",
-                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                    "country": "United States"
+                                    "country": "United States",
+                                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                                   },
                                   "commissionable": true,
                                   "name": "Archery lesson",
@@ -21043,8 +21043,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -21054,8 +21054,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "financialBreakdown": {
             "displayPriceQuote": {
@@ -21460,8 +21460,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -21497,18 +21497,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -22207,15 +22207,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -22445,8 +22445,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -22456,8 +22456,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -23085,8 +23085,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 }
               ],
               "petInfo": [
@@ -23353,6 +23353,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -23370,9 +23373,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -23579,8 +23579,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -24027,8 +24027,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -24959,8 +24959,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -24970,8 +24970,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -25170,8 +25170,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -25181,8 +25181,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -25381,11 +25381,11 @@
                   }
                 ]
               },
-              "userSpecifiedCurrencyAveragePricePerNight": {
+              "internalAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
-              "internalAveragePricePerNight": {
+              "userSpecifiedCurrencyAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -25619,8 +25619,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -25630,8 +25630,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "financialBreakdown": {
                   "displayPriceQuote": {
@@ -25771,8 +25771,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     }
                   ],
                   "petInfo": [
@@ -26224,8 +26224,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -26235,8 +26235,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -26435,11 +26435,11 @@
                 }
               ]
             },
-            "userSpecifiedCurrencyAveragePricePerNight": {
+            "internalAveragePricePerNight": {
               "amount": 1250,
               "currency": "USD"
             },
-            "internalAveragePricePerNight": {
+            "userSpecifiedCurrencyAveragePricePerNight": {
               "amount": 1250,
               "currency": "USD"
             },
@@ -26673,8 +26673,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -26684,8 +26684,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -26825,8 +26825,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   }
                 ],
                 "petInfo": [
@@ -26966,12 +26966,12 @@
             "default": "",
             "description": "Guest assigned to this room stay (lead occupant). Null during search/availability; set at checkout."
           },
-          "rateSource": {
-            "type": "string"
-          },
           "guests": {
             "type": "integer",
             "format": "int32"
+          },
+          "rateSource": {
+            "type": "string"
           },
           "sourceTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
@@ -27009,8 +27009,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -27056,18 +27056,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -27436,11 +27436,11 @@
               }
             ]
           },
-          "userSpecifiedCurrencyAveragePricePerNight": {
+          "internalAveragePricePerNight": {
             "amount": 1250,
             "currency": "USD"
           },
-          "internalAveragePricePerNight": {
+          "userSpecifiedCurrencyAveragePricePerNight": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -27675,10 +27675,10 @@
           "totalDiscountPercent": {
             "type": "number"
           },
-          "userSpecifiedCurrencyAveragePricePerNight": {
+          "internalAveragePricePerNight": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "internalAveragePricePerNight": {
+          "userSpecifiedCurrencyAveragePricePerNight": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
           "sourceAveragePricePerNight": {
@@ -27900,15 +27900,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -27952,10 +27952,10 @@
               "quantity": 1
             }
           ],
-          "guests": 4,
-          "rooms": 2,
           "hours": 72,
-          "children": 1
+          "children": 1,
+          "guests": 4,
+          "rooms": 2
         },
         "properties": {
           "startDate": {
@@ -27995,20 +27995,6 @@
               "default": ""
             }
           },
-          "guests": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "Total number of adult guests across all rooms",
-            "example": 4
-          },
-          "rooms": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "Total number of rooms in this itinerary",
-            "example": 2
-          },
           "hours": {
             "type": "integer",
             "format": "int64",
@@ -28023,6 +28009,20 @@
             "default": "",
             "description": "Total number of children across all rooms",
             "example": 1
+          },
+          "guests": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "Total number of adult guests across all rooms",
+            "example": 4
+          },
+          "rooms": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "Total number of rooms in this itinerary",
+            "example": 2
           }
         },
         "required": [
@@ -28052,10 +28052,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -28369,10 +28369,10 @@
                 "quantity": 1
               }
             ],
-            "guests": 4,
-            "rooms": 2,
             "hours": 72,
-            "children": 1
+            "children": 1,
+            "guests": 4,
+            "rooms": 2
           },
           "language": "en",
           "currency": "USD",
@@ -28516,8 +28516,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -28527,8 +28527,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -29087,8 +29087,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -29098,8 +29098,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -29893,8 +29893,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -29930,18 +29930,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -30441,8 +30441,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -30452,8 +30452,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -31219,6 +31219,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -31236,9 +31239,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -31769,11 +31769,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -31974,8 +31974,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -31985,8 +31985,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -32414,8 +32414,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -32425,8 +32425,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -32689,11 +32689,11 @@
                         "amount": 1250,
                         "currency": "USD"
                       },
-                      "userSpecifiedCurrencyAveragePricePerNight": {
+                      "internalAveragePricePerNight": {
                         "amount": 1250,
                         "currency": "USD"
                       },
-                      "internalAveragePricePerNight": {
+                      "userSpecifiedCurrencyAveragePricePerNight": {
                         "amount": 1250,
                         "currency": "USD"
                       },
@@ -32894,8 +32894,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -32905,8 +32905,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -34312,11 +34312,11 @@
                   "amount": 1250,
                   "currency": "USD"
                 },
-                "userSpecifiedCurrencyAveragePricePerNight": {
+                "internalAveragePricePerNight": {
                   "amount": 1250,
                   "currency": "USD"
                 },
-                "internalAveragePricePerNight": {
+                "userSpecifiedCurrencyAveragePricePerNight": {
                   "amount": 1250,
                   "currency": "USD"
                 },
@@ -34517,8 +34517,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -34528,8 +34528,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -34957,8 +34957,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34968,8 +34968,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -35232,11 +35232,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -35437,8 +35437,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -35448,8 +35448,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -36599,11 +36599,11 @@
               "amount": 1250,
               "currency": "USD"
             },
-            "userSpecifiedCurrencyAveragePricePerNight": {
+            "internalAveragePricePerNight": {
               "amount": 1250,
               "currency": "USD"
             },
-            "internalAveragePricePerNight": {
+            "userSpecifiedCurrencyAveragePricePerNight": {
               "amount": 1250,
               "currency": "USD"
             },
@@ -36804,8 +36804,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -36815,8 +36815,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -37556,11 +37556,11 @@
                 "amount": 1250,
                 "currency": "USD"
               },
-              "userSpecifiedCurrencyAveragePricePerNight": {
+              "internalAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
-              "internalAveragePricePerNight": {
+              "userSpecifiedCurrencyAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -37761,8 +37761,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -37772,8 +37772,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -38196,8 +38196,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -38243,18 +38243,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -38577,11 +38577,11 @@
             "amount": 1250,
             "currency": "USD"
           },
-          "userSpecifiedCurrencyAveragePricePerNight": {
+          "internalAveragePricePerNight": {
             "amount": 1250,
             "currency": "USD"
           },
-          "internalAveragePricePerNight": {
+          "userSpecifiedCurrencyAveragePricePerNight": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -38813,10 +38813,10 @@
           "totalDiscountPercent": {
             "type": "number"
           },
-          "userSpecifiedCurrencyAveragePricePerNight": {
+          "internalAveragePricePerNight": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "internalAveragePricePerNight": {
+          "userSpecifiedCurrencyAveragePricePerNight": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
           "sourceAveragePricePerNight": {
@@ -38945,10 +38945,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -39031,10 +39031,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -39131,10 +39131,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -39239,10 +39239,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -39347,10 +39347,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -39457,10 +39457,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -39649,8 +39649,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -39660,8 +39660,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -40108,8 +40108,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -40119,8 +40119,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -40598,8 +40598,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -40609,8 +40609,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -41050,8 +41050,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -41061,8 +41061,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -41423,8 +41423,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -41434,8 +41434,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -41966,8 +41966,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -41977,8 +41977,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -42388,8 +42388,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -42399,8 +42399,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -42832,8 +42832,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -42843,8 +42843,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -43536,14 +43536,6 @@
             "default": "",
             "description": "Sales channel that owns this booking"
           },
-          "available": {
-            "type": "boolean"
-          },
-          "lowestPrice": {
-            "$ref": "#/components/schemas/RoomTypeWithPriceConfiguration_Non_Authenticated_Entity",
-            "default": "",
-            "description": "Uses the content from roomTypes and shows the room type with the lowest price."
-          },
           "cheapestRoomTypes": {
             "type": "array",
             "default": "",
@@ -43551,6 +43543,14 @@
             "items": {
               "$ref": "#/components/schemas/RoomTypeWithPriceConfiguration_Non_Authenticated_Entity"
             }
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "lowestPrice": {
+            "$ref": "#/components/schemas/RoomTypeWithPriceConfiguration_Non_Authenticated_Entity",
+            "default": "",
+            "description": "Uses the content from roomTypes and shows the room type with the lowest price."
           }
         }
       },
@@ -43612,8 +43612,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -43623,8 +43623,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -44145,8 +44145,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -44156,8 +44156,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -44521,8 +44521,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -44532,8 +44532,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -44793,11 +44793,11 @@
                 "amount": 1250,
                 "currency": "USD"
               },
-              "userSpecifiedCurrencyAveragePricePerNight": {
+              "internalAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
-              "internalAveragePricePerNight": {
+              "userSpecifiedCurrencyAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -44998,8 +44998,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -45009,8 +45009,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -45458,8 +45458,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -45469,8 +45469,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -45731,11 +45731,11 @@
                   "amount": 1250,
                   "currency": "USD"
                 },
-                "userSpecifiedCurrencyAveragePricePerNight": {
+                "internalAveragePricePerNight": {
                   "amount": 1250,
                   "currency": "USD"
                 },
-                "internalAveragePricePerNight": {
+                "userSpecifiedCurrencyAveragePricePerNight": {
                   "amount": 1250,
                   "currency": "USD"
                 },
@@ -45936,8 +45936,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -45947,8 +45947,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -46509,11 +46509,11 @@
                 "amount": 1250,
                 "currency": "USD"
               },
-              "userSpecifiedCurrencyAveragePricePerNight": {
+              "internalAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
-              "internalAveragePricePerNight": {
+              "userSpecifiedCurrencyAveragePricePerNight": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -46714,8 +46714,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -46725,8 +46725,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -47222,8 +47222,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -47233,8 +47233,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -47672,8 +47672,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -47683,8 +47683,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -48136,10 +48136,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -48253,8 +48253,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -48264,8 +48264,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -48788,11 +48788,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -48993,8 +48993,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -49004,8 +49004,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -49433,8 +49433,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -49444,8 +49444,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -49708,11 +49708,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -49913,8 +49913,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -49924,8 +49924,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -50393,8 +50393,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -50404,8 +50404,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -50929,11 +50929,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -51134,8 +51134,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -51145,8 +51145,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -51574,8 +51574,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -51585,8 +51585,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -51849,11 +51849,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -52054,8 +52054,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -52065,8 +52065,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -52534,8 +52534,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -52545,8 +52545,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -53070,11 +53070,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -53275,8 +53275,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -53286,8 +53286,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -53715,8 +53715,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -53726,8 +53726,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -53990,11 +53990,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -54195,8 +54195,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -54206,8 +54206,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -54950,8 +54950,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -54961,8 +54961,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -55496,11 +55496,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -55701,8 +55701,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -55712,8 +55712,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -56141,8 +56141,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -56152,8 +56152,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -56416,11 +56416,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -56621,8 +56621,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -56632,8 +56632,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -57192,8 +57192,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -57203,8 +57203,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -57727,11 +57727,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -57932,8 +57932,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -57943,8 +57943,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -58372,8 +58372,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -58383,8 +58383,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -58647,11 +58647,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -58852,8 +58852,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -58863,8 +58863,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -59332,8 +59332,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -59343,8 +59343,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -59872,11 +59872,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -60077,8 +60077,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -60088,8 +60088,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -60517,8 +60517,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -60528,8 +60528,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -60792,11 +60792,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -60997,8 +60997,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -61008,8 +61008,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -61763,8 +61763,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -61774,8 +61774,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -62297,11 +62297,11 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "userSpecifiedCurrencyAveragePricePerNight": {
+                  "internalAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
-                  "internalAveragePricePerNight": {
+                  "userSpecifiedCurrencyAveragePricePerNight": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -62502,8 +62502,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -62513,8 +62513,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -62942,8 +62942,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -62953,8 +62953,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -63217,11 +63217,11 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "userSpecifiedCurrencyAveragePricePerNight": {
+                    "internalAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
-                    "internalAveragePricePerNight": {
+                    "userSpecifiedCurrencyAveragePricePerNight": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -63422,8 +63422,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -63433,8 +63433,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -63864,10 +63864,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -64297,7 +64297,9 @@
           "ratePlanNameMatchesRegEx": {
             "type": "string",
             "default": "",
-            "description": "A regular expression to apply to the rate plan name"
+            "description": "A regular expression to apply to the rate plan name",
+            "maxLength": 256,
+            "minLength": 0
           }
         },
         "required": [
@@ -64595,10 +64597,10 @@
                       "quantity": 1
                     }
                   ],
-                  "guests": 4,
-                  "rooms": 2,
                   "hours": 72,
-                  "children": 1
+                  "children": 1,
+                  "guests": 4,
+                  "rooms": 2
                 },
                 "language": "en",
                 "currency": "USD",
@@ -65021,10 +65023,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65100,10 +65102,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65231,10 +65233,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65394,10 +65396,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65541,10 +65543,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65662,10 +65664,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65805,10 +65807,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -65969,10 +65971,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -66126,10 +66128,10 @@
                   "quantity": 1
                 }
               ],
-              "guests": 4,
-              "rooms": 2,
               "hours": 72,
-              "children": 1
+              "children": 1,
+              "guests": 4,
+              "rooms": 2
             },
             "language": "en",
             "currency": "USD",
@@ -66450,7 +66452,13 @@
           "redirectUrl": "https://book.wink.travel/thank-you",
           "ga4ClientId": "G-XHFTY1BDSD",
           "ga4SessionId": "GA.1.1.123456789.1234567890",
-          "ga4MeasurementId": "GA.1.1.123456789.1234567890"
+          "ga4MeasurementId": "GA.1.1.123456789.1234567890",
+          "quotedTotal": {
+            "sourceAmount": 4480,
+            "sourceCurrency": "THB",
+            "displayAmount": 4480,
+            "displayCurrency": "THB"
+          }
         },
         "properties": {
           "shoppingCartIdentifier": {
@@ -66501,11 +66509,57 @@
             },
             "default": "",
             "description": "GA4 session IDs the browser captured before the Stripe redirect, keyed by Measurement ID (G-XXXX -> session_id). Lets the server continue each measurement ID's original session when firing the purchase server-side."
+          },
+          "quotedTotal": {
+            "$ref": "#/components/schemas/QuotedCartTotal_Authenticated_Entity",
+            "default": "",
+            "description": "The cart total the client displayed to the guest. Asserted against the server's own re-price before any payment object is created; never used as a price. Optional so older clients keep working while the guard rolls out."
           }
         },
         "required": [
           "redirectUrl",
           "shoppingCartIdentifier"
+        ]
+      },
+      "QuotedCartTotal_Authenticated_Entity": {
+        "type": "object",
+        "default": null,
+        "description": "The cart total the client displayed to the guest, used by the server purely to assert that its re-price still matches. Never used as a price.",
+        "example": {
+          "sourceAmount": 4480,
+          "sourceCurrency": "THB",
+          "displayAmount": 4480,
+          "displayCurrency": "THB"
+        },
+        "properties": {
+          "sourceAmount": {
+            "type": "number",
+            "default": "",
+            "description": "Total in the property's own (source) currency, if the client can independently attest one. Omit rather than echoing back a server-supplied figure.",
+            "example": 4480
+          },
+          "sourceCurrency": {
+            "type": "string",
+            "default": "",
+            "description": "ISO 4217 code of the property's own (source) currency. Required when sourceAmount is present.",
+            "example": "THB"
+          },
+          "displayAmount": {
+            "type": "number",
+            "default": "",
+            "description": "Total in the guest's display currency, exactly as rendered on the confirm step",
+            "example": 4480
+          },
+          "displayCurrency": {
+            "type": "string",
+            "default": "",
+            "description": "ISO 4217 code of the guest's display currency",
+            "example": "THB"
+          }
+        },
+        "required": [
+          "displayAmount",
+          "displayCurrency"
         ]
       },
       "CheckoutResult_Authenticated_Entity": {
@@ -67813,7 +67867,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "account.read": "View your account settings.",
               "account.write": "Create and update your account settings.",

--- a/schemas/channel-manager.json
+++ b/schemas/channel-manager.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.2",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-integrations.wink.travel:8445",
+      "url": "https://integrations.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Channel managers can use this endpoint to integrate. It contains all the features a channel manager would need to query properties, update rate and availability and retrieve bookings.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-integrations.wink.travel:8445/scalar#channel-manager/tag/channel-manager"
+        "url": "https://integrations.wink.travel/scalar#channel-manager/tag/channel-manager"
       }
     }
   ],
@@ -3023,7 +3023,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "integrations.read": "View your channel manager integrations.",
               "integrations.write": "Create and update your channel manager integrations.",

--- a/schemas/extranet.json
+++ b/schemas/extranet.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Manage property lifestyles using this endpoint.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/lifestyle"
+        "url": "https://api.wink.travel/scalar#extranet/tag/lifestyle"
       }
     },
     {
@@ -42,7 +42,7 @@
       "description": "Manage reservation schedules and calendar items for travel inventory such as meeting rooms, restaurants, spas, activities, attractions, and places. Enables creating, reading, updating, and deleting scheduled events with support for recurring events, timezone handling, and attendee management.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/scheduler"
+        "url": "https://api.wink.travel/scalar#extranet/tag/scheduler"
       }
     },
     {
@@ -50,7 +50,7 @@
       "description": "Sales Channels are direct relationships between property and affiliate. Account relationships are initiated by either affiliate or hotel and allows for hotels to give sales channel specific pricing to affiliates on an individual basis.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/sales-channel"
+        "url": "https://api.wink.travel/scalar#extranet/tag/sales-channel"
       }
     },
     {
@@ -58,7 +58,7 @@
       "description": "Create, read, update, and delete promotions (discounts and premiums) with complex qualification rules. Promotions can reduce or increase rates based on guest location, booking lead time, length of stay, promo codes, and many other criteria.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/promotion"
+        "url": "https://api.wink.travel/scalar#extranet/tag/promotion"
       }
     },
     {
@@ -66,7 +66,7 @@
       "description": "Manage property cancellation policies. Cancellation policies dictate when and if a traveler is entitled to a full / partial / no refund.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/cancellation-policy"
+        "url": "https://api.wink.travel/scalar#extranet/tag/cancellation-policy"
       }
     },
     {
@@ -74,7 +74,7 @@
       "description": "Manage the general manager profile for your property.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/general-manager"
+        "url": "https://api.wink.travel/scalar#extranet/tag/general-manager"
       }
     },
     {
@@ -82,7 +82,7 @@
       "description": "Manage daily rates and availability for your master rates using these endpoints.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/daily-rate"
+        "url": "https://api.wink.travel/scalar#extranet/tag/daily-rate"
       }
     },
     {
@@ -90,7 +90,7 @@
       "description": "Manage bundles of related promotions. Bundle multiple promotions together to apply coordinated discounts or to simplify offerDetails presentation to guests.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/promotion-bundle"
+        "url": "https://api.wink.travel/scalar#extranet/tag/promotion-bundle"
       }
     },
     {
@@ -98,7 +98,7 @@
       "description": "Manage rate plans that control inventory availability and pricing terms. Rate plans restrict which combinations of master rates, packages, and add-ons can be sold to guests, allowing fine-grained revenue management by date, occupancy, length of stay, and more.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/rate-plan"
+        "url": "https://api.wink.travel/scalar#extranet/tag/rate-plan"
       }
     },
     {
@@ -106,7 +106,7 @@
       "description": "Manage property room types.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/guest-room"
+        "url": "https://api.wink.travel/scalar#extranet/tag/guest-room"
       }
     },
     {
@@ -114,7 +114,7 @@
       "description": "Retrieve and analyze booking metrics, including property performance, affiliate overview, revenue trends, and detailed time-series analytics.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/analytics"
+        "url": "https://api.wink.travel/scalar#extranet/tag/analytics"
       }
     },
     {
@@ -122,7 +122,7 @@
       "description": "This is the endpoint you will want to work first with to begin the process of adding your properties onto the wink.travel platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/registration"
+        "url": "https://api.wink.travel/scalar#extranet/tag/registration"
       }
     },
     {
@@ -130,7 +130,7 @@
       "description": "Manage which social networks the property is connected to.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/social-network"
+        "url": "https://api.wink.travel/scalar#extranet/tag/social-network"
       }
     },
     {
@@ -138,7 +138,7 @@
       "description": "Activities are things travelers can do in and around the property. They can be free, for informational purposes only, or they can be bookable and commissionable. The goal of any property is to create as many sellable activities and become more attractive to potential guests by being able to offer more than their competition.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/activity"
+        "url": "https://api.wink.travel/scalar#extranet/tag/activity"
       }
     },
     {
@@ -146,7 +146,7 @@
       "description": "Places are points of interest travelers visit in and around the property. They can be free, for informational purposes only, or they can be bookable and commissionable. The goal of any property is to create as many sellable places and become more attractive to potential guests by being able to offer more than their competition.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/place"
+        "url": "https://api.wink.travel/scalar#extranet/tag/place"
       }
     },
     {
@@ -154,7 +154,7 @@
       "description": "Manage property geo-location.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/geo-location"
+        "url": "https://api.wink.travel/scalar#extranet/tag/geo-location"
       }
     },
     {
@@ -162,7 +162,7 @@
       "description": "Add-ons are ancillary inventorythat can be added onto a room booking. It can be literally anything; from a tangible to an intangible good. Note that an add-on can also be made mandatory such as an extra water plane ride to your final island destination in the Maldives or an obligatory Christmas dinner.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/add-on"
+        "url": "https://api.wink.travel/scalar#extranet/tag/add-on"
       }
     },
     {
@@ -170,7 +170,7 @@
       "description": "Account relationships are initiated by either affiliate or hotel and allows for hotels to give sales channel specific pricing to affiliates on an individual basis.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/sales-channel-request"
+        "url": "https://api.wink.travel/scalar#extranet/tag/sales-channel-request"
       }
     },
     {
@@ -178,7 +178,7 @@
       "description": "Booking endpoints allow you to create and cancel bookings as well as to retrieve all bookings.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/test-booking"
+        "url": "https://api.wink.travel/scalar#extranet/tag/test-booking"
       }
     },
     {
@@ -186,7 +186,7 @@
       "description": "A property can associate multiple types of third-party online / offline acknowledgements to their profile in the form of awards, reviews / ratings, articles and more.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/recognition"
+        "url": "https://api.wink.travel/scalar#extranet/tag/recognition"
       }
     },
     {
@@ -194,7 +194,7 @@
       "description": "Booking endpoints allow you to create and cancel bookings as well as to retrieve all bookings.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/booking"
+        "url": "https://api.wink.travel/scalar#extranet/tag/booking"
       }
     },
     {
@@ -202,7 +202,7 @@
       "description": "Manage your properties",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/property"
+        "url": "https://api.wink.travel/scalar#extranet/tag/property"
       }
     },
     {
@@ -210,7 +210,7 @@
       "description": "Endpoints for determining if a a sales channel is currently using the specific inventory.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/inventory-usage"
+        "url": "https://api.wink.travel/scalar#extranet/tag/inventory-usage"
       }
     },
     {
@@ -218,7 +218,7 @@
       "description": "Browse affiliates with their sales metrics and invite new affiliate partners.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/affiliate"
+        "url": "https://api.wink.travel/scalar#extranet/tag/affiliate"
       }
     },
     {
@@ -226,7 +226,7 @@
       "description": "Generate and export your booking data as a CSV file.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/reports"
+        "url": "https://api.wink.travel/scalar#extranet/tag/reports"
       }
     },
     {
@@ -234,7 +234,7 @@
       "description": "Properties can create date-based announcements for travelers. These announcements are returned in HotelInventoryResponse if the itinerary matches the announcement date.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/announcement"
+        "url": "https://api.wink.travel/scalar#extranet/tag/announcement"
       }
     },
     {
@@ -242,7 +242,7 @@
       "description": "Inventory API allows you to control which inventory you want to make available at the sales channel level.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/inventory"
+        "url": "https://api.wink.travel/scalar#extranet/tag/inventory"
       }
     },
     {
@@ -250,7 +250,7 @@
       "description": "CalDAV integration endpoints that enable properties to sync their bookings with external calendar applications (iCal-compatible clients like Google Calendar, Apple Calendar, Outlook, etc.). Generate and manage secure CalDAV feed URLs and authentication keys.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/calendar-sync"
+        "url": "https://api.wink.travel/scalar#extranet/tag/calendar-sync"
       }
     },
     {
@@ -258,7 +258,7 @@
       "description": "Manage property policy such as whether the property allows children and pets.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/policy"
+        "url": "https://api.wink.travel/scalar#extranet/tag/policy"
       }
     },
     {
@@ -266,7 +266,7 @@
       "description": "Generate, refine and save your property's welcome description.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/welcome-text"
+        "url": "https://api.wink.travel/scalar#extranet/tag/welcome-text"
       }
     },
     {
@@ -274,7 +274,7 @@
       "description": "Manage meeting rooms that are on and off the premises. Make them viewable-only or let travelers book a meeting room together with their room.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/meeting-room"
+        "url": "https://api.wink.travel/scalar#extranet/tag/meeting-room"
       }
     },
     {
@@ -282,7 +282,7 @@
       "description": "Travelers can leave reviews after a booking has taken place. Properties can see these reviews and also respond to them.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/review"
+        "url": "https://api.wink.travel/scalar#extranet/tag/review"
       }
     },
     {
@@ -290,7 +290,7 @@
       "description": "Restaurants are eating establishments travelers can go to to get a meal in and around the property. They can be free, for informational purposes only, or they can be bookable and commissionable. The goal of any property is to create as many bookable restaurants and become more attractive to potential guests by being able to offer more than their competition.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/restaurant"
+        "url": "https://api.wink.travel/scalar#extranet/tag/restaurant"
       }
     },
     {
@@ -298,7 +298,7 @@
       "description": "Master Rates are room types + rules and restrictions that get sold to and booked by travelers. A master rate consists simply of a guest room and a rate plan with the added ability to give away perks to travelers to incentivize them to book this master rate. \n\nNote: The inventory works with rate plan-level availability. This means you assign the master rate availability and not the room type. You set initial availability on the room type / guest room, but you can override on the master rate level. This gives you more flexibility in how you want to sell your rooms. I.e. you can give more availability to a master rate than another with the same room but different rate plan. You can also overbook that room type.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/master-rate"
+        "url": "https://api.wink.travel/scalar#extranet/tag/master-rate"
       }
     },
     {
@@ -306,7 +306,7 @@
       "description": "Attractions are things travelers visit in and around the property. They can be free, for informational purposes only, or they can be bookable and commissionable. The goal of any property is to create as many sellable attractions and become more attractive to potential guests by being able to offer more than their competition.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/attraction"
+        "url": "https://api.wink.travel/scalar#extranet/tag/attraction"
       }
     },
     {
@@ -314,7 +314,7 @@
       "description": "Indicate which channel manager the property is using. This can be done either during property invite or using this endpoint. If it is not done during the invite phase, the channel manager defaults to `TRAVELIKO` which is the same as no channel manager and rate ownership goes to the inventory.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/channel-manager"
+        "url": "https://api.wink.travel/scalar#extranet/tag/channel-manager"
       }
     },
     {
@@ -322,7 +322,7 @@
       "description": "Spas are health establishments travelers can go to to get a massage or similar in and around the property. They can be free, for informational purposes only, or they can be bookable and commissionable. The goal of any property is to create as many bookable spas and become more attractive to potential guests by being able to offer more than their competition.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/spa"
+        "url": "https://api.wink.travel/scalar#extranet/tag/spa"
       }
     },
     {
@@ -330,7 +330,7 @@
       "description": "Manage property media including images and videos. Property media are for general pictures of the hotel such as main featured image, around premises, lobby etc. For all other media, each travel inventorysection contains its own section for managing media.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#extranet/tag/media"
+        "url": "https://api.wink.travel/scalar#extranet/tag/media"
       }
     }
   ],
@@ -4444,7 +4444,7 @@
                   ],
                   "createdDate": "2026-01-14T09:30:00",
                   "lastUpdate": "2026-02-03T16:45:12",
-                  "aggregatedItemDescriptions": [
+                  "effectiveDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -4452,7 +4452,7 @@
                       "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                     }
                   ],
-                  "effectiveDescriptions": [
+                  "aggregatedItemDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -4858,7 +4858,7 @@
                   ],
                   "createdDate": "2026-01-14T09:30:00",
                   "lastUpdate": "2026-02-03T16:45:12",
-                  "aggregatedItemDescriptions": [
+                  "effectiveDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -4866,7 +4866,7 @@
                       "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                     }
                   ],
-                  "effectiveDescriptions": [
+                  "aggregatedItemDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -5282,7 +5282,7 @@
                   ],
                   "createdDate": "2026-01-14T09:30:00",
                   "lastUpdate": "2026-02-03T16:45:12",
-                  "aggregatedItemDescriptions": [
+                  "effectiveDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -5290,7 +5290,7 @@
                       "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                     }
                   ],
-                  "effectiveDescriptions": [
+                  "aggregatedItemDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -5556,8 +5556,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -5567,8 +5567,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -5931,8 +5931,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -5942,8 +5942,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -6296,8 +6296,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -6307,8 +6307,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -6665,8 +6665,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -6676,8 +6676,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -7075,8 +7075,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -7086,8 +7086,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -7475,8 +7475,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -7486,8 +7486,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -7875,8 +7875,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -7886,8 +7886,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -8256,8 +8256,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -8267,8 +8267,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -8627,8 +8627,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -8638,8 +8638,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -9000,8 +9000,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -9011,8 +9011,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -9387,8 +9387,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -9398,8 +9398,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -9764,8 +9764,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -9775,8 +9775,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -10143,8 +10143,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -10154,8 +10154,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -10519,8 +10519,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -10530,8 +10530,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -10885,8 +10885,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -10896,8 +10896,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -11253,8 +11253,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -11264,8 +11264,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -11630,8 +11630,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -11641,8 +11641,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -11997,8 +11997,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -12008,8 +12008,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -12366,8 +12366,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -12377,8 +12377,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -12742,8 +12742,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -12753,8 +12753,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -13108,8 +13108,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -13119,8 +13119,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -14798,8 +14798,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -14809,8 +14809,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -15327,8 +15327,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -15338,8 +15338,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -18152,7 +18152,7 @@
                       ],
                       "createdDate": "2026-01-14T09:30:00",
                       "lastUpdate": "2026-02-03T16:45:12",
-                      "aggregatedItemDescriptions": [
+                      "effectiveDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -18160,7 +18160,7 @@
                           "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                         }
                       ],
-                      "effectiveDescriptions": [
+                      "aggregatedItemDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -18751,7 +18751,7 @@
                       ],
                       "createdDate": "2026-01-14T09:30:00",
                       "lastUpdate": "2026-02-03T16:45:12",
-                      "aggregatedItemDescriptions": [
+                      "effectiveDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -18759,7 +18759,7 @@
                           "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                         }
                       ],
-                      "effectiveDescriptions": [
+                      "aggregatedItemDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -19360,7 +19360,7 @@
                       ],
                       "createdDate": "2026-01-14T09:30:00",
                       "lastUpdate": "2026-02-03T16:45:12",
-                      "aggregatedItemDescriptions": [
+                      "effectiveDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -19368,7 +19368,7 @@
                           "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                         }
                       ],
-                      "effectiveDescriptions": [
+                      "aggregatedItemDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -20191,7 +20191,7 @@
                         ],
                         "createdDate": "2026-01-14T09:30:00",
                         "lastUpdate": "2026-02-03T16:45:12",
-                        "aggregatedItemDescriptions": [
+                        "effectiveDescriptions": [
                           {
                             "description": "This is a longer description in the specified language.",
                             "language": "en",
@@ -20199,7 +20199,7 @@
                             "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                           }
                         ],
-                        "effectiveDescriptions": [
+                        "aggregatedItemDescriptions": [
                           {
                             "description": "This is a longer description in the specified language.",
                             "language": "en",
@@ -21023,7 +21023,7 @@
                         ],
                         "createdDate": "2026-01-14T09:30:00",
                         "lastUpdate": "2026-02-03T16:45:12",
-                        "aggregatedItemDescriptions": [
+                        "effectiveDescriptions": [
                           {
                             "description": "This is a longer description in the specified language.",
                             "language": "en",
@@ -21031,7 +21031,7 @@
                             "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                           }
                         ],
-                        "effectiveDescriptions": [
+                        "aggregatedItemDescriptions": [
                           {
                             "description": "This is a longer description in the specified language.",
                             "language": "en",
@@ -21737,8 +21737,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -21748,8 +21748,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "created": "2026-01-14T09:30:00",
                     "lastModified": "2026-02-03T16:45:12",
@@ -25093,7 +25093,7 @@
                         ],
                         "createdDate": "2026-01-14T09:30:00",
                         "lastUpdate": "2026-02-03T16:45:12",
-                        "aggregatedItemDescriptions": [
+                        "effectiveDescriptions": [
                           {
                             "description": "This is a longer description in the specified language.",
                             "language": "en",
@@ -25101,7 +25101,7 @@
                             "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                           }
                         ],
-                        "effectiveDescriptions": [
+                        "aggregatedItemDescriptions": [
                           {
                             "description": "This is a longer description in the specified language.",
                             "language": "en",
@@ -27507,7 +27507,7 @@
                     ],
                     "createdDate": "2026-01-14T09:30:00",
                     "lastUpdate": "2026-02-03T16:45:12",
-                    "aggregatedItemDescriptions": [
+                    "effectiveDescriptions": [
                       {
                         "description": "This is a longer description in the specified language.",
                         "language": "en",
@@ -27515,7 +27515,7 @@
                         "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                       }
                     ],
-                    "effectiveDescriptions": [
+                    "aggregatedItemDescriptions": [
                       {
                         "description": "This is a longer description in the specified language.",
                         "language": "en",
@@ -30164,8 +30164,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -30175,8 +30175,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -30739,8 +30739,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -30750,8 +30750,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -31139,8 +31139,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -31150,8 +31150,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -31719,8 +31719,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -31730,8 +31730,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -32305,8 +32305,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -32316,8 +32316,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -32880,8 +32880,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -32891,8 +32891,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -33456,8 +33456,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -33467,8 +33467,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -34931,8 +34931,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -34942,8 +34942,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -35578,8 +35578,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -35589,8 +35589,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -35730,8 +35730,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -35759,6 +35759,18 @@
                     },
                     "startDate": "2025-12-24",
                     "endDate": "2025-12-27",
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
                     "beneficiaryList": [
                       {
                         "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -35790,19 +35802,7 @@
                         "netInternalAmount": 450,
                         "reconciled": false
                       }
-                    ],
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
+                    ]
                   },
                   "booker": {
                     "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
@@ -36223,6 +36223,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -36293,8 +36495,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -36304,8 +36506,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -36425,8 +36627,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -36436,8 +36638,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -36557,8 +36759,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -36568,8 +36770,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -36689,8 +36891,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -36700,8 +36902,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -36821,8 +37023,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -36832,8 +37034,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -36953,8 +37155,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -36964,8 +37166,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -37085,8 +37419,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -37096,242 +37430,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -37382,142 +37482,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -37527,6 +37491,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -37541,7 +37509,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -38952,8 +38952,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -38963,8 +38963,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -39447,8 +39447,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -39458,8 +39458,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -39599,8 +39599,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 }
                               ],
                               "petInfo": [
@@ -40060,6 +40060,208 @@
                           "currency": "USD"
                         }
                       ],
+                      "guestUser": {
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "reservations@thesiamresidences.com",
+                        "telephone": "+1 212 555 1212",
+                        "profile": {
+                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                          "createdDate": "2026-01-14T09:30:00",
+                          "lastUpdate": "2026-02-03T16:45:12",
+                          "version": 3,
+                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                          "share": true,
+                          "user": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "alexandra@beaumont.com",
+                            "phone": "+66212658866",
+                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                            "fullName": "Alexandra Beaumont"
+                          },
+                          "personal": {
+                            "gender": "FEMALE",
+                            "birthDate": "1985-06-15",
+                            "maritalStatus": "MARRIED",
+                            "childQuantity": 2,
+                            "citizenship": "Thailand",
+                            "address1": "123 Petchburi Road",
+                            "address2": "Ratchathewi District",
+                            "city": "Bangkok",
+                            "state": "Bangkok",
+                            "postalCode": "10400",
+                            "country": "TH",
+                            "preferredCurrency": "USD",
+                            "language": "en",
+                            "contactPerson": [
+                              {
+                                "firstName": "Alexandra",
+                                "lastName": "Beaumont",
+                                "email": "johnsmith@email.com",
+                                "secondaryEmail": "johnsmith2@email.com",
+                                "phoneNumber": "+12125551212",
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                              }
+                            ],
+                            "petInfo": [
+                              {
+                                "name": "Luna",
+                                "type": "Golden Retriever"
+                              }
+                            ]
+                          },
+                          "preferences": {
+                            "propertyLocationPref": "Beachfront",
+                            "propertyTypePref": "Luxury Resort",
+                            "hotelChainPref": "Mandarin Oriental",
+                            "physChalFeaturePref": "Wheelchair accessible rooms",
+                            "smokingAllowed": false,
+                            "roomLocationPref": "High floor with city view",
+                            "bedTypePref": "King bed",
+                            "foodSrvcPref": "In-room dining",
+                            "guestType": "Business traveler",
+                            "mealPref": "Continental breakfast",
+                            "cuisinePref": "Thai"
+                          }
+                        },
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "ancillaryList": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
                       "meetingRooms": [
                         {
                           "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -40130,8 +40332,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40141,8 +40343,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -40262,8 +40464,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40273,8 +40475,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -40394,8 +40596,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40405,8 +40607,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -40526,8 +40728,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40537,8 +40739,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -40658,8 +40860,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40669,8 +40871,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -40790,8 +40992,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40801,8 +41003,140 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "roomTypeAncillaries": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -40922,8 +41256,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -40933,242 +41267,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ],
-                      "guestUser": {
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "reservations@thesiamresidences.com",
-                        "telephone": "+1 212 555 1212",
-                        "profile": {
-                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                          "createdDate": "2026-01-14T09:30:00",
-                          "lastUpdate": "2026-02-03T16:45:12",
-                          "version": 3,
-                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                          "share": true,
-                          "user": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "alexandra@beaumont.com",
-                            "phone": "+66212658866",
-                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "personal": {
-                            "gender": "FEMALE",
-                            "birthDate": "1985-06-15",
-                            "maritalStatus": "MARRIED",
-                            "childQuantity": 2,
-                            "citizenship": "Thailand",
-                            "address1": "123 Petchburi Road",
-                            "address2": "Ratchathewi District",
-                            "city": "Bangkok",
-                            "state": "Bangkok",
-                            "postalCode": "10400",
-                            "country": "TH",
-                            "preferredCurrency": "USD",
-                            "language": "en",
-                            "contactPerson": [
-                              {
-                                "firstName": "Alexandra",
-                                "lastName": "Beaumont",
-                                "email": "johnsmith@email.com",
-                                "secondaryEmail": "johnsmith2@email.com",
-                                "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
-                              }
-                            ],
-                            "petInfo": [
-                              {
-                                "name": "Luna",
-                                "type": "Golden Retriever"
-                              }
-                            ]
-                          },
-                          "preferences": {
-                            "propertyLocationPref": "Beachfront",
-                            "propertyTypePref": "Luxury Resort",
-                            "hotelChainPref": "Mandarin Oriental",
-                            "physChalFeaturePref": "Wheelchair accessible rooms",
-                            "smokingAllowed": false,
-                            "roomLocationPref": "High floor with city view",
-                            "bedTypePref": "King bed",
-                            "foodSrvcPref": "In-room dining",
-                            "guestType": "Business traveler",
-                            "mealPref": "Continental breakfast",
-                            "cuisinePref": "Thai"
-                          }
-                        },
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "ancillaryList": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -41219,142 +41319,6 @@
                         }
                       ],
                       "cancellable": false,
-                      "roomTypeAncillaries": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "totalPaymentProcessingFeeSourceAmount": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
                       "netTotalSalesSourceAmountOrZero": {
                         "amount": 1250,
                         "currency": "USD"
@@ -41364,6 +41328,10 @@
                         "currency": "USD"
                       },
                       "totalPlatformFeeSourceAmount": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "totalPaymentProcessingFeeSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
                       },
@@ -41378,7 +41346,39 @@
                       "totalSupplierAgencyFeesSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
-                      }
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
                     }
                   ],
                   "number": 0,
@@ -41868,8 +41868,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -41879,8 +41879,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -48467,8 +48467,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -48478,8 +48478,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -49638,8 +49638,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -49649,8 +49649,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -51044,8 +51044,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -51055,8 +51055,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -52218,8 +52218,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -52229,8 +52229,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -53398,8 +53398,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -53409,8 +53409,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -54567,8 +54567,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -54578,8 +54578,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -55737,8 +55737,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -55748,8 +55748,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -56559,8 +56559,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -56570,8 +56570,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -57054,8 +57054,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -57065,8 +57065,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -57206,8 +57206,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 }
                               ],
                               "petInfo": [
@@ -57667,6 +57667,208 @@
                           "currency": "USD"
                         }
                       ],
+                      "guestUser": {
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "reservations@thesiamresidences.com",
+                        "telephone": "+1 212 555 1212",
+                        "profile": {
+                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                          "createdDate": "2026-01-14T09:30:00",
+                          "lastUpdate": "2026-02-03T16:45:12",
+                          "version": 3,
+                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                          "share": true,
+                          "user": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "alexandra@beaumont.com",
+                            "phone": "+66212658866",
+                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                            "fullName": "Alexandra Beaumont"
+                          },
+                          "personal": {
+                            "gender": "FEMALE",
+                            "birthDate": "1985-06-15",
+                            "maritalStatus": "MARRIED",
+                            "childQuantity": 2,
+                            "citizenship": "Thailand",
+                            "address1": "123 Petchburi Road",
+                            "address2": "Ratchathewi District",
+                            "city": "Bangkok",
+                            "state": "Bangkok",
+                            "postalCode": "10400",
+                            "country": "TH",
+                            "preferredCurrency": "USD",
+                            "language": "en",
+                            "contactPerson": [
+                              {
+                                "firstName": "Alexandra",
+                                "lastName": "Beaumont",
+                                "email": "johnsmith@email.com",
+                                "secondaryEmail": "johnsmith2@email.com",
+                                "phoneNumber": "+12125551212",
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                              }
+                            ],
+                            "petInfo": [
+                              {
+                                "name": "Luna",
+                                "type": "Golden Retriever"
+                              }
+                            ]
+                          },
+                          "preferences": {
+                            "propertyLocationPref": "Beachfront",
+                            "propertyTypePref": "Luxury Resort",
+                            "hotelChainPref": "Mandarin Oriental",
+                            "physChalFeaturePref": "Wheelchair accessible rooms",
+                            "smokingAllowed": false,
+                            "roomLocationPref": "High floor with city view",
+                            "bedTypePref": "King bed",
+                            "foodSrvcPref": "In-room dining",
+                            "guestType": "Business traveler",
+                            "mealPref": "Continental breakfast",
+                            "cuisinePref": "Thai"
+                          }
+                        },
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "ancillaryList": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
                       "meetingRooms": [
                         {
                           "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -57737,8 +57939,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -57748,8 +57950,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -57869,8 +58071,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -57880,8 +58082,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -58001,8 +58203,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -58012,8 +58214,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -58133,8 +58335,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -58144,8 +58346,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -58265,8 +58467,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -58276,8 +58478,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -58397,8 +58599,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -58408,8 +58610,140 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "roomTypeAncillaries": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -58529,8 +58863,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -58540,242 +58874,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ],
-                      "guestUser": {
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "reservations@thesiamresidences.com",
-                        "telephone": "+1 212 555 1212",
-                        "profile": {
-                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                          "createdDate": "2026-01-14T09:30:00",
-                          "lastUpdate": "2026-02-03T16:45:12",
-                          "version": 3,
-                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                          "share": true,
-                          "user": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "alexandra@beaumont.com",
-                            "phone": "+66212658866",
-                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "personal": {
-                            "gender": "FEMALE",
-                            "birthDate": "1985-06-15",
-                            "maritalStatus": "MARRIED",
-                            "childQuantity": 2,
-                            "citizenship": "Thailand",
-                            "address1": "123 Petchburi Road",
-                            "address2": "Ratchathewi District",
-                            "city": "Bangkok",
-                            "state": "Bangkok",
-                            "postalCode": "10400",
-                            "country": "TH",
-                            "preferredCurrency": "USD",
-                            "language": "en",
-                            "contactPerson": [
-                              {
-                                "firstName": "Alexandra",
-                                "lastName": "Beaumont",
-                                "email": "johnsmith@email.com",
-                                "secondaryEmail": "johnsmith2@email.com",
-                                "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
-                              }
-                            ],
-                            "petInfo": [
-                              {
-                                "name": "Luna",
-                                "type": "Golden Retriever"
-                              }
-                            ]
-                          },
-                          "preferences": {
-                            "propertyLocationPref": "Beachfront",
-                            "propertyTypePref": "Luxury Resort",
-                            "hotelChainPref": "Mandarin Oriental",
-                            "physChalFeaturePref": "Wheelchair accessible rooms",
-                            "smokingAllowed": false,
-                            "roomLocationPref": "High floor with city view",
-                            "bedTypePref": "King bed",
-                            "foodSrvcPref": "In-room dining",
-                            "guestType": "Business traveler",
-                            "mealPref": "Continental breakfast",
-                            "cuisinePref": "Thai"
-                          }
-                        },
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "ancillaryList": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -58826,142 +58926,6 @@
                         }
                       ],
                       "cancellable": false,
-                      "roomTypeAncillaries": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "totalPaymentProcessingFeeSourceAmount": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
                       "netTotalSalesSourceAmountOrZero": {
                         "amount": 1250,
                         "currency": "USD"
@@ -58971,6 +58935,10 @@
                         "currency": "USD"
                       },
                       "totalPlatformFeeSourceAmount": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "totalPaymentProcessingFeeSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
                       },
@@ -58985,7 +58953,39 @@
                       "totalSupplierAgencyFeesSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
-                      }
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
                     }
                   ],
                   "number": 0,
@@ -60067,8 +60067,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -60078,8 +60078,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -60763,8 +60763,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -60774,8 +60774,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "created": "2026-01-14T09:30:00",
                   "lastModified": "2026-02-03T16:45:12",
@@ -61033,8 +61033,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -61044,8 +61044,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "created": "2026-01-14T09:30:00",
                   "lastModified": "2026-02-03T16:45:12",
@@ -62264,8 +62264,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -62275,8 +62275,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -62653,8 +62653,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -62664,8 +62664,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -63044,8 +63044,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -63055,8 +63055,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -63466,8 +63466,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -63477,8 +63477,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -64099,8 +64099,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -64110,8 +64110,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -64494,8 +64494,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -64505,8 +64505,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -64891,8 +64891,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -64902,8 +64902,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -65292,8 +65292,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -65303,8 +65303,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -65695,8 +65695,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -65706,8 +65706,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -66085,8 +66085,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -66096,8 +66096,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -66477,8 +66477,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -66488,8 +66488,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -66868,8 +66868,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -66879,8 +66879,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -67261,8 +67261,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -67272,8 +67272,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -67651,8 +67651,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -67662,8 +67662,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -70021,8 +70021,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -70032,8 +70032,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -70412,8 +70412,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -70423,8 +70423,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -70791,8 +70791,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -70802,8 +70802,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -71170,8 +71170,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -71181,8 +71181,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -71549,8 +71549,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -71560,8 +71560,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -71928,8 +71928,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -71939,8 +71939,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -72307,8 +72307,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -72318,8 +72318,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -72686,8 +72686,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -72697,8 +72697,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -73065,8 +73065,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -73076,8 +73076,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -73444,8 +73444,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -73455,8 +73455,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -73823,8 +73823,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -73834,8 +73834,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -74214,8 +74214,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -74225,8 +74225,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -74638,8 +74638,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -74649,8 +74649,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -75050,8 +75050,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -75061,8 +75061,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -75462,8 +75462,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -75473,8 +75473,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -75874,8 +75874,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -75885,8 +75885,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -76286,8 +76286,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -76297,8 +76297,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -76698,8 +76698,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -76709,8 +76709,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -77110,8 +77110,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -77121,8 +77121,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -77522,8 +77522,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -77533,8 +77533,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -77934,8 +77934,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -77945,8 +77945,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -78346,8 +78346,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -78357,8 +78357,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -78770,8 +78770,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -78781,8 +78781,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -79167,8 +79167,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -79178,8 +79178,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -79552,8 +79552,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -79563,8 +79563,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -79937,8 +79937,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -79948,8 +79948,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -80322,8 +80322,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -80333,8 +80333,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -80707,8 +80707,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -80718,8 +80718,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -81092,8 +81092,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -81103,8 +81103,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -81477,8 +81477,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -81488,8 +81488,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -81862,8 +81862,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -81873,8 +81873,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -82247,8 +82247,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -82258,8 +82258,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -82632,8 +82632,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -82643,8 +82643,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -83029,8 +83029,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -83040,8 +83040,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -83432,8 +83432,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -83443,8 +83443,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -83823,8 +83823,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -83834,8 +83834,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -84214,8 +84214,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -84225,8 +84225,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -84605,8 +84605,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -84616,8 +84616,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -84996,8 +84996,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -85007,8 +85007,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -85387,8 +85387,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -85398,8 +85398,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -85778,8 +85778,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -85789,8 +85789,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -86169,8 +86169,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -86180,8 +86180,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -86560,8 +86560,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -86571,8 +86571,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -86951,8 +86951,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -86962,8 +86962,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -87354,8 +87354,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -87365,8 +87365,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -87746,8 +87746,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -87757,8 +87757,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -88126,8 +88126,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -88137,8 +88137,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -88506,8 +88506,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -88517,8 +88517,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -88886,8 +88886,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -88897,8 +88897,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -89266,8 +89266,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -89277,8 +89277,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -89646,8 +89646,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -89657,8 +89657,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -90026,8 +90026,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -90037,8 +90037,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -90406,8 +90406,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -90417,8 +90417,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -90786,8 +90786,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -90797,8 +90797,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -91178,8 +91178,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -91189,8 +91189,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -91571,8 +91571,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -91582,8 +91582,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -91952,8 +91952,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -91963,8 +91963,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -92333,8 +92333,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -92344,8 +92344,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -92714,8 +92714,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -92725,8 +92725,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -93095,8 +93095,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -93106,8 +93106,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -93476,8 +93476,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -93487,8 +93487,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -93857,8 +93857,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -93868,8 +93868,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -94238,8 +94238,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -94249,8 +94249,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -94619,8 +94619,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -94630,8 +94630,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -95012,8 +95012,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -95023,8 +95023,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -95404,8 +95404,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -95415,8 +95415,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -95784,8 +95784,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -95795,8 +95795,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -96164,8 +96164,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -96175,8 +96175,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -96544,8 +96544,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -96555,8 +96555,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -96924,8 +96924,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -96935,8 +96935,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -97304,8 +97304,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -97315,8 +97315,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -97684,8 +97684,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -97695,8 +97695,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -98064,8 +98064,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -98075,8 +98075,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -98444,8 +98444,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -98455,8 +98455,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -98824,8 +98824,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -98835,8 +98835,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -99709,8 +99709,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -99720,8 +99720,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -100204,8 +100204,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -100215,8 +100215,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -100356,8 +100356,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -100817,6 +100817,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -100887,8 +101089,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -100898,8 +101100,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101019,8 +101221,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -101030,8 +101232,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101151,8 +101353,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -101162,8 +101364,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101283,8 +101485,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -101294,8 +101496,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101415,8 +101617,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -101426,8 +101628,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101547,8 +101749,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -101558,8 +101760,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101679,8 +102013,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -101690,242 +102024,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -101976,142 +102076,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -102121,6 +102085,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -102135,7 +102103,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -102487,8 +102487,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -102498,8 +102498,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -102982,8 +102982,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -102993,8 +102993,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -103134,8 +103134,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -103595,6 +103595,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -103665,8 +103867,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -103676,8 +103878,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -103797,8 +103999,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -103808,8 +104010,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -103929,8 +104131,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -103940,8 +104142,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -104061,8 +104263,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -104072,8 +104274,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -104193,8 +104395,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -104204,8 +104406,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -104325,8 +104527,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -104336,8 +104538,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -104457,8 +104791,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -104468,242 +104802,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -104754,142 +104854,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -104899,6 +104863,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -104913,7 +104881,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -105183,8 +105183,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -105194,8 +105194,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -105715,8 +105715,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -105726,8 +105726,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -106247,8 +106247,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -106258,8 +106258,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -106779,8 +106779,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -106790,8 +106790,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -107311,8 +107311,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -107322,8 +107322,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -107841,8 +107841,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -107852,8 +107852,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -108373,8 +108373,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -108384,8 +108384,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -108905,8 +108905,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -108916,8 +108916,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -109437,8 +109437,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -109448,8 +109448,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -109969,8 +109969,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -109980,8 +109980,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -110501,8 +110501,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -110512,8 +110512,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -111250,8 +111250,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -111261,8 +111261,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -111631,8 +111631,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -111642,8 +111642,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -112042,8 +112042,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -112053,8 +112053,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -112426,8 +112426,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -112437,8 +112437,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -112788,8 +112788,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -112825,18 +112825,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -112881,8 +112881,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -112892,8 +112892,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "created": "2026-01-14T09:30:00",
           "lastModified": "2026-02-03T16:45:12",
@@ -113175,8 +113175,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -113222,18 +113222,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -115321,15 +115321,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -119459,7 +119459,7 @@
           ],
           "createdDate": "2026-01-14T09:30:00",
           "lastUpdate": "2026-02-03T16:45:12",
-          "aggregatedItemDescriptions": [
+          "effectiveDescriptions": [
             {
               "description": "This is a longer description in the specified language.",
               "language": "en",
@@ -119467,7 +119467,7 @@
               "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
             }
           ],
-          "effectiveDescriptions": [
+          "aggregatedItemDescriptions": [
             {
               "description": "This is a longer description in the specified language.",
               "language": "en",
@@ -119598,6 +119598,16 @@
             "example": "2026-02-03T16:45:12",
             "readOnly": true
           },
+          "isValid": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "effectiveDescriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocalizedDescription_Supplier"
+            }
+          },
           "aggregatedItemDescriptions": {
             "type": "array",
             "items": {
@@ -119609,16 +119619,6 @@
           },
           "hasPercentDiscountModifier": {
             "type": "boolean"
-          },
-          "effectiveDescriptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LocalizedDescription_Supplier"
-            }
-          },
-          "isValid": {
-            "type": "boolean",
-            "writeOnly": true
           }
         },
         "required": [
@@ -120021,8 +120021,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -120032,8 +120032,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -120473,8 +120473,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -120484,8 +120484,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -121219,8 +121219,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -121235,8 +121235,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "socials": [
             {
@@ -121891,8 +121891,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -121902,8 +121902,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -122670,8 +122670,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -122681,8 +122681,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -123207,8 +123207,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -123218,8 +123218,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -123800,8 +123800,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -123811,8 +123811,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -124347,8 +124347,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -124358,8 +124358,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -124950,8 +124950,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -124961,8 +124961,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -125399,8 +125399,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -125410,8 +125410,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -125860,8 +125860,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -125897,18 +125897,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -125987,15 +125987,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -126037,8 +126037,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -126084,18 +126084,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -126690,8 +126690,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -126701,8 +126701,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -127184,8 +127184,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -127195,8 +127195,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -127786,8 +127786,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -127797,8 +127797,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -128249,8 +128249,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -128260,8 +128260,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -128775,8 +128775,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -128786,8 +128786,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -129621,8 +129621,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -129632,8 +129632,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -130107,8 +130107,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -130118,8 +130118,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -131742,8 +131742,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "location": {
             "type": "POINT",
@@ -131760,8 +131760,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "revenue": {
             "firstName": "Alexandra",
@@ -131769,8 +131769,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "marketing": {
             "firstName": "Alexandra",
@@ -131778,8 +131778,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "descriptions": [
             {
@@ -133102,8 +133102,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -133113,8 +133113,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -133794,8 +133794,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -133805,8 +133805,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -135029,8 +135029,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -135066,18 +135066,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -135398,6 +135398,22 @@
             "amount": 1250,
             "currency": "USD"
           },
+          "sourceRate": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "userSpecifiedCurrencyRate": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "internalRate": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "baseRate": {
+            "amount": 1250,
+            "currency": "USD"
+          },
           "beneficiaryList": [
             {
               "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -135429,23 +135445,7 @@
               "netInternalAmount": 450,
               "reconciled": false
             }
-          ],
-          "baseRate": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "sourceRate": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "internalRate": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "userSpecifiedCurrencyRate": {
-            "amount": 1250,
-            "currency": "USD"
-          }
+          ]
         },
         "properties": {
           "sourceBaseRate": {
@@ -135623,40 +135623,9 @@
             "default": "",
             "description": "Final per-night rate in user specified currency (base + modifiers). Computed at instantiation."
           },
-          "startDate": {
-            "type": "boolean"
-          },
-          "lastNight": {
-            "type": "boolean"
-          },
-          "rateIdentifier": {
-            "type": "string"
-          },
-          "betweenDate": {
-            "type": "boolean"
-          },
-          "bundledModifier": {
-            "type": "boolean"
-          },
-          "closeOnArrival": {
-            "type": "boolean"
-          },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
-            }
-          },
-          "baseRate": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "minLOS": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "maxLOS": {
-            "type": "integer",
-            "format": "int32"
+          "date": {
+            "type": "string",
+            "format": "date"
           },
           "maxOccupancy": {
             "type": "integer",
@@ -135666,27 +135635,17 @@
             "type": "integer",
             "format": "int32"
           },
-          "source": {
-            "type": "string"
-          },
-          "quantity": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "sourceRate": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "internalRate": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "endDate": {
-            "type": "boolean"
-          },
-          "userSpecifiedCurrencyRate": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
           "totalDiscountPercent": {
             "type": "number"
+          },
+          "startDate": {
+            "type": "boolean"
+          },
+          "lastNight": {
+            "type": "boolean"
+          },
+          "rateIdentifier": {
+            "type": "string"
           },
           "closeOnDeparture": {
             "type": "boolean"
@@ -135697,9 +135656,50 @@
           "masterAvailability": {
             "type": "boolean"
           },
-          "date": {
-            "type": "string",
-            "format": "date"
+          "closeOnArrival": {
+            "type": "boolean"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "type": "string"
+          },
+          "betweenDate": {
+            "type": "boolean"
+          },
+          "bundledModifier": {
+            "type": "boolean"
+          },
+          "sourceRate": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "userSpecifiedCurrencyRate": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "internalRate": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "minLOS": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxLOS": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "baseRate": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "endDate": {
+            "type": "boolean"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
+            }
           }
         },
         "required": [
@@ -135869,8 +135869,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -135880,8 +135880,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -136345,6 +136345,22 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
+                  "sourceRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "userSpecifiedCurrencyRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "internalRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "baseRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
                   "beneficiaryList": [
                     {
                       "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -136376,23 +136392,7 @@
                       "netInternalAmount": 450,
                       "reconciled": false
                     }
-                  ],
-                  "baseRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "sourceRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "internalRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "userSpecifiedCurrencyRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  }
+                  ]
                 }
               ],
               "userSpecifiedCurrencyTotal": {
@@ -136453,6 +136453,18 @@
                   }
                 ]
               },
+              "internalAveragePricePerNight": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "userSpecifiedCurrencyAveragePricePerNight": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "sourceAveragePricePerNight": {
+                "amount": 1250,
+                "currency": "USD"
+              },
               "beneficiaryList": [
                 {
                   "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -136484,19 +136496,7 @@
                   "netInternalAmount": 450,
                   "reconciled": false
                 }
-              ],
-              "userSpecifiedCurrencyAveragePricePerNight": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "internalAveragePricePerNight": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "sourceAveragePricePerNight": {
-                "amount": 1250,
-                "currency": "USD"
-              }
+              ]
             },
             "extraCharges": {
               "items": [
@@ -136690,8 +136690,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -136701,8 +136701,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -137514,6 +137514,22 @@
                       "amount": 1250,
                       "currency": "USD"
                     },
+                    "sourceRate": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyRate": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalRate": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "baseRate": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
                     "beneficiaryList": [
                       {
                         "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -137545,23 +137561,7 @@
                         "netInternalAmount": 450,
                         "reconciled": false
                       }
-                    ],
-                    "baseRate": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceRate": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalRate": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyRate": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
+                    ]
                   }
                 ],
                 "userSpecifiedCurrencyTotal": {
@@ -137622,6 +137622,18 @@
                     }
                   ]
                 },
+                "internalAveragePricePerNight": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyAveragePricePerNight": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceAveragePricePerNight": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
                 "beneficiaryList": [
                   {
                     "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -137653,19 +137665,7 @@
                     "netInternalAmount": 450,
                     "reconciled": false
                   }
-                ],
-                "userSpecifiedCurrencyAveragePricePerNight": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalAveragePricePerNight": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceAveragePricePerNight": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
+                ]
               },
               "extraCharges": {
                 "items": [
@@ -137859,8 +137859,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -137870,8 +137870,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -139099,15 +139099,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -139169,8 +139169,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -139180,8 +139180,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -140333,6 +140333,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -140350,9 +140353,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -141906,6 +141906,22 @@
                   "amount": 1250,
                   "currency": "USD"
                 },
+                "sourceRate": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyRate": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalRate": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "baseRate": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
                 "beneficiaryList": [
                   {
                     "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -141937,23 +141953,7 @@
                     "netInternalAmount": 450,
                     "reconciled": false
                   }
-                ],
-                "baseRate": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceRate": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalRate": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyRate": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
+                ]
               }
             ],
             "userSpecifiedCurrencyTotal": {
@@ -142014,6 +142014,18 @@
                 }
               ]
             },
+            "internalAveragePricePerNight": {
+              "amount": 1250,
+              "currency": "USD"
+            },
+            "userSpecifiedCurrencyAveragePricePerNight": {
+              "amount": 1250,
+              "currency": "USD"
+            },
+            "sourceAveragePricePerNight": {
+              "amount": 1250,
+              "currency": "USD"
+            },
             "beneficiaryList": [
               {
                 "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -142045,19 +142057,7 @@
                 "netInternalAmount": 450,
                 "reconciled": false
               }
-            ],
-            "userSpecifiedCurrencyAveragePricePerNight": {
-              "amount": 1250,
-              "currency": "USD"
-            },
-            "internalAveragePricePerNight": {
-              "amount": 1250,
-              "currency": "USD"
-            },
-            "sourceAveragePricePerNight": {
-              "amount": 1250,
-              "currency": "USD"
-            }
+            ]
           },
           "extraCharges": {
             "items": [
@@ -142251,8 +142251,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -142262,8 +142262,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "commissionable": true,
                 "name": "Archery lesson",
@@ -143005,8 +143005,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -143016,8 +143016,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -144064,7 +144064,7 @@
               ],
               "createdDate": "2026-01-14T09:30:00",
               "lastUpdate": "2026-02-03T16:45:12",
-              "aggregatedItemDescriptions": [
+              "effectiveDescriptions": [
                 {
                   "description": "This is a longer description in the specified language.",
                   "language": "en",
@@ -144072,7 +144072,7 @@
                   "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                 }
               ],
-              "effectiveDescriptions": [
+              "aggregatedItemDescriptions": [
                 {
                   "description": "This is a longer description in the specified language.",
                   "language": "en",
@@ -144274,8 +144274,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -144321,18 +144321,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -144807,7 +144807,7 @@
           ],
           "createdDate": "2026-01-14T09:30:00",
           "lastUpdate": "2026-02-03T16:45:12",
-          "aggregatedItemDescriptions": [
+          "effectiveDescriptions": [
             {
               "description": "This is a longer description in the specified language.",
               "language": "en",
@@ -144815,7 +144815,7 @@
               "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
             }
           ],
-          "effectiveDescriptions": [
+          "aggregatedItemDescriptions": [
             {
               "description": "This is a longer description in the specified language.",
               "language": "en",
@@ -144946,6 +144946,16 @@
             "example": "2026-02-03T16:45:12",
             "readOnly": true
           },
+          "isValid": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "effectiveDescriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocalizedDescription_SupplierDetails"
+            }
+          },
           "aggregatedItemDescriptions": {
             "type": "array",
             "items": {
@@ -144957,16 +144967,6 @@
           },
           "hasPercentDiscountModifier": {
             "type": "boolean"
-          },
-          "effectiveDescriptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LocalizedDescription_SupplierDetails"
-            }
-          },
-          "isValid": {
-            "type": "boolean",
-            "writeOnly": true
           }
         },
         "required": [
@@ -145681,6 +145681,22 @@
                 "amount": 1250,
                 "currency": "USD"
               },
+              "sourceRate": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "userSpecifiedCurrencyRate": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "internalRate": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "baseRate": {
+                "amount": 1250,
+                "currency": "USD"
+              },
               "beneficiaryList": [
                 {
                   "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -145712,23 +145728,7 @@
                   "netInternalAmount": 450,
                   "reconciled": false
                 }
-              ],
-              "baseRate": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "sourceRate": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "internalRate": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "userSpecifiedCurrencyRate": {
-                "amount": 1250,
-                "currency": "USD"
-              }
+              ]
             }
           ],
           "userSpecifiedCurrencyTotal": {
@@ -145789,6 +145789,18 @@
               }
             ]
           },
+          "internalAveragePricePerNight": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "userSpecifiedCurrencyAveragePricePerNight": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "sourceAveragePricePerNight": {
+            "amount": 1250,
+            "currency": "USD"
+          },
           "beneficiaryList": [
             {
               "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -145820,19 +145832,7 @@
               "netInternalAmount": 450,
               "reconciled": false
             }
-          ],
-          "userSpecifiedCurrencyAveragePricePerNight": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "internalAveragePricePerNight": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "sourceAveragePricePerNight": {
-            "amount": 1250,
-            "currency": "USD"
-          }
+          ]
         },
         "properties": {
           "userSpecifiedCurrencyBaseTotal": {
@@ -146063,23 +146063,23 @@
           "financialBreakdown": {
             "$ref": "#/components/schemas/FinancialBreakdown_SupplierDetails"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
+          "internalAveragePricePerNight": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "userSpecifiedCurrencyAveragePricePerNight": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "sourceAveragePricePerNight": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
           "beneficiaryList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
             }
-          },
-          "totalDiscountPercent": {
-            "type": "number"
-          },
-          "userSpecifiedCurrencyAveragePricePerNight": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "internalAveragePricePerNight": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "sourceAveragePricePerNight": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
           }
         }
       },
@@ -146805,6 +146805,22 @@
                     "amount": 1250,
                     "currency": "USD"
                   },
+                  "sourceRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "userSpecifiedCurrencyRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "internalRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "baseRate": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
                   "beneficiaryList": [
                     {
                       "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -146836,23 +146852,7 @@
                       "netInternalAmount": 450,
                       "reconciled": false
                     }
-                  ],
-                  "baseRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "sourceRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "internalRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "userSpecifiedCurrencyRate": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  }
+                  ]
                 }
               ],
               "userSpecifiedCurrencyTotal": {
@@ -146913,6 +146913,18 @@
                   }
                 ]
               },
+              "internalAveragePricePerNight": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "userSpecifiedCurrencyAveragePricePerNight": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "sourceAveragePricePerNight": {
+                "amount": 1250,
+                "currency": "USD"
+              },
               "beneficiaryList": [
                 {
                   "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -146944,19 +146956,7 @@
                   "netInternalAmount": 450,
                   "reconciled": false
                 }
-              ],
-              "userSpecifiedCurrencyAveragePricePerNight": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "internalAveragePricePerNight": {
-                "amount": 1250,
-                "currency": "USD"
-              },
-              "sourceAveragePricePerNight": {
-                "amount": 1250,
-                "currency": "USD"
-              }
+              ]
             },
             "extraCharges": {
               "items": [
@@ -147150,8 +147150,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -147161,8 +147161,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -147817,8 +147817,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -147828,8 +147828,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "financialBreakdown": {
             "displayPriceQuote": {
@@ -148543,18 +148543,6 @@
               "default": ""
             }
           },
-          "guests": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total guests for this stay"
-          },
-          "rooms": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total rooms for this stay"
-          },
           "hours": {
             "type": "integer",
             "format": "int64",
@@ -148567,6 +148555,18 @@
             "format": "int32",
             "default": "",
             "description": "How many total children for this stay"
+          },
+          "guests": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total guests for this stay"
+          },
+          "rooms": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total rooms for this stay"
           }
         },
         "required": [
@@ -148724,8 +148724,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -148735,8 +148735,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -149371,8 +149371,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -149382,8 +149382,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "financialBreakdown": {
                   "displayPriceQuote": {
@@ -149523,8 +149523,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     }
                   ],
                   "petInfo": [
@@ -149552,6 +149552,18 @@
             },
             "startDate": "2025-12-24",
             "endDate": "2025-12-27",
+            "sourceTotal": {
+              "amount": 1250,
+              "currency": "USD"
+            },
+            "internalTotal": {
+              "amount": 1250,
+              "currency": "USD"
+            },
+            "userSpecifiedCurrencyTotal": {
+              "amount": 1250,
+              "currency": "USD"
+            },
             "beneficiaryList": [
               {
                 "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -149583,19 +149595,7 @@
                 "netInternalAmount": 450,
                 "reconciled": false
               }
-            ],
-            "sourceTotal": {
-              "amount": 1250,
-              "currency": "USD"
-            },
-            "internalTotal": {
-              "amount": 1250,
-              "currency": "USD"
-            },
-            "userSpecifiedCurrencyTotal": {
-              "amount": 1250,
-              "currency": "USD"
-            }
+            ]
           },
           "booker": {
             "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
@@ -150016,6 +150016,208 @@
               "currency": "USD"
             }
           ],
+          "guestUser": {
+            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+            "firstName": "Alexandra",
+            "lastName": "Beaumont",
+            "email": "reservations@thesiamresidences.com",
+            "telephone": "+1 212 555 1212",
+            "profile": {
+              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+              "createdDate": "2026-01-14T09:30:00",
+              "lastUpdate": "2026-02-03T16:45:12",
+              "version": 3,
+              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+              "share": true,
+              "user": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "alexandra@beaumont.com",
+                "phone": "+66212658866",
+                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                "fullName": "Alexandra Beaumont"
+              },
+              "personal": {
+                "gender": "FEMALE",
+                "birthDate": "1985-06-15",
+                "maritalStatus": "MARRIED",
+                "childQuantity": 2,
+                "citizenship": "Thailand",
+                "address1": "123 Petchburi Road",
+                "address2": "Ratchathewi District",
+                "city": "Bangkok",
+                "state": "Bangkok",
+                "postalCode": "10400",
+                "country": "TH",
+                "preferredCurrency": "USD",
+                "language": "en",
+                "contactPerson": [
+                  {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  }
+                ],
+                "petInfo": [
+                  {
+                    "name": "Luna",
+                    "type": "Golden Retriever"
+                  }
+                ]
+              },
+              "preferences": {
+                "propertyLocationPref": "Beachfront",
+                "propertyTypePref": "Luxury Resort",
+                "hotelChainPref": "Mandarin Oriental",
+                "physChalFeaturePref": "Wheelchair accessible rooms",
+                "smokingAllowed": false,
+                "roomLocationPref": "High floor with city view",
+                "bedTypePref": "King bed",
+                "foodSrvcPref": "In-room dining",
+                "guestType": "Business traveler",
+                "mealPref": "Continental breakfast",
+                "cuisinePref": "Thai"
+              }
+            },
+            "fullName": "Alexandra Beaumont"
+          },
+          "ancillaryList": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
           "meetingRooms": [
             {
               "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -150086,8 +150288,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150097,8 +150299,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -150218,8 +150420,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150229,8 +150431,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -150350,8 +150552,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150361,8 +150563,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -150482,8 +150684,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150493,8 +150695,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -150614,8 +150816,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150625,8 +150827,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -150746,8 +150948,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150757,8 +150959,140 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
+          "roomTypeAncillaries": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -150878,8 +151212,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -150889,242 +151223,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "beneficiaryList": [
-            {
-              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-              "accountName": "The Siam Residences, Bangkok",
-              "accountEmail": "reservations@thesiamresidences.com",
-              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-              "amountDue": {
-                "percent": 0.05
-              },
-              "sourceCurrency": "THB",
-              "displayCurrency": "USD",
-              "internalCurrency": "USD",
-              "sourceAmount": 450,
-              "displayAmount": 450,
-              "internalAmount": 450,
-              "sourceAmountRefundModifier": 45,
-              "displayAmountRefundModifier": 45,
-              "internalAmountRefundModifier": 45,
-              "pendingRefunds": [
-                {
-                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45
-                }
-              ],
-              "netSourceAmount": 450,
-              "netDisplayAmount": 450,
-              "netInternalAmount": 450,
-              "reconciled": false
-            }
-          ],
-          "guestUser": {
-            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-            "firstName": "Alexandra",
-            "lastName": "Beaumont",
-            "email": "reservations@thesiamresidences.com",
-            "telephone": "+1 212 555 1212",
-            "profile": {
-              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-              "createdDate": "2026-01-14T09:30:00",
-              "lastUpdate": "2026-02-03T16:45:12",
-              "version": 3,
-              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-              "share": true,
-              "user": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "alexandra@beaumont.com",
-                "phone": "+66212658866",
-                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                "fullName": "Alexandra Beaumont"
-              },
-              "personal": {
-                "gender": "FEMALE",
-                "birthDate": "1985-06-15",
-                "maritalStatus": "MARRIED",
-                "childQuantity": 2,
-                "citizenship": "Thailand",
-                "address1": "123 Petchburi Road",
-                "address2": "Ratchathewi District",
-                "city": "Bangkok",
-                "state": "Bangkok",
-                "postalCode": "10400",
-                "country": "TH",
-                "preferredCurrency": "USD",
-                "language": "en",
-                "contactPerson": [
-                  {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  }
-                ],
-                "petInfo": [
-                  {
-                    "name": "Luna",
-                    "type": "Golden Retriever"
-                  }
-                ]
-              },
-              "preferences": {
-                "propertyLocationPref": "Beachfront",
-                "propertyTypePref": "Luxury Resort",
-                "hotelChainPref": "Mandarin Oriental",
-                "physChalFeaturePref": "Wheelchair accessible rooms",
-                "smokingAllowed": false,
-                "roomLocationPref": "High floor with city view",
-                "bedTypePref": "King bed",
-                "foodSrvcPref": "In-room dining",
-                "guestType": "Business traveler",
-                "mealPref": "Continental breakfast",
-                "cuisinePref": "Thai"
-              }
-            },
-            "fullName": "Alexandra Beaumont"
-          },
-          "ancillaryList": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -151175,142 +151275,6 @@
             }
           ],
           "cancellable": false,
-          "roomTypeAncillaries": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "totalPaymentProcessingFeeSourceAmount": {
-            "amount": 1250,
-            "currency": "USD"
-          },
           "netTotalSalesSourceAmountOrZero": {
             "amount": 1250,
             "currency": "USD"
@@ -151320,6 +151284,10 @@
             "currency": "USD"
           },
           "totalPlatformFeeSourceAmount": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "totalPaymentProcessingFeeSourceAmount": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -151334,7 +151302,39 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "amount": 1250,
             "currency": "USD"
-          }
+          },
+          "beneficiaryList": [
+            {
+              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+              "accountName": "The Siam Residences, Bangkok",
+              "accountEmail": "reservations@thesiamresidences.com",
+              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+              "amountDue": {
+                "percent": 0.05
+              },
+              "sourceCurrency": "THB",
+              "displayCurrency": "USD",
+              "internalCurrency": "USD",
+              "sourceAmount": 450,
+              "displayAmount": 450,
+              "internalAmount": 450,
+              "sourceAmountRefundModifier": 45,
+              "displayAmountRefundModifier": 45,
+              "internalAmountRefundModifier": 45,
+              "pendingRefunds": [
+                {
+                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45
+                }
+              ],
+              "netSourceAmount": 450,
+              "netDisplayAmount": 450,
+              "netInternalAmount": 450,
+              "reconciled": false
+            }
+          ]
         },
         "properties": {
           "id": {
@@ -151750,6 +151750,28 @@
               "default": ""
             }
           },
+          "cancelled": {
+            "type": "boolean"
+          },
+          "rateSource": {
+            "type": "string"
+          },
+          "cancelledOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guestUser": {
+            "$ref": "#/components/schemas/GuestUser_SupplierDetails"
+          },
+          "cancelReason": {
+            "type": "string"
+          },
+          "ancillaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_SupplierDetails"
+            }
+          },
           "meetingRooms": {
             "type": "array",
             "items": {
@@ -151786,38 +151808,50 @@
               "$ref": "#/components/schemas/BookingAncillary_SupplierDetails"
             }
           },
+          "roomTypeAncillaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_SupplierDetails"
+            }
+          },
           "addOns": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BookingAncillary_SupplierDetails"
             }
           },
-          "rateSource": {
+          "cancellationType": {
+            "type": "string",
+            "description": "Reason category for a booking cancellation",
+            "enum": [
+              "DUPLICATE",
+              "CANCELLATION",
+              "NO_SHOW",
+              "CC_INVALID",
+              "CC_INSUFFICIENT",
+              "DISCRETIONARY"
+            ],
+            "default": null
+          },
+          "cancellable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
+          },
+          "displayCurrency": {
             "type": "string"
-          },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
-            }
-          },
-          "agentPayment": {
-            "type": "boolean"
-          },
-          "guestUser": {
-            "$ref": "#/components/schemas/GuestUser_SupplierDetails"
-          },
-          "ancillaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_SupplierDetails"
-            }
-          },
-          "agentSelfManaged": {
-            "type": "boolean"
           },
           "roomImageUrl": {
             "type": "string"
+          },
+          "netDisplayAmount": {
+            "type": "number"
+          },
+          "netTotalSalesSourceAmountOrZero": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "netSourceAmountOrZero": {
+            "type": "number"
           },
           "hasRefunds": {
             "type": "boolean"
@@ -151833,55 +151867,6 @@
             ],
             "default": null
           },
-          "cancelledOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cancellable": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
-          },
-          "displayCurrency": {
-            "type": "string"
-          },
-          "cancelReason": {
-            "type": "string"
-          },
-          "cancellationType": {
-            "type": "string",
-            "description": "Reason category for a booking cancellation",
-            "enum": [
-              "DUPLICATE",
-              "CANCELLATION",
-              "NO_SHOW",
-              "CC_INVALID",
-              "CC_INSUFFICIENT",
-              "DISCRETIONARY"
-            ],
-            "default": null
-          },
-          "paymentTransactionIdentifier": {
-            "type": "string"
-          },
-          "roomTypeAncillaries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_SupplierDetails"
-            }
-          },
-          "totalPaymentProcessingFeeSourceAmount": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netDisplayAmount": {
-            "type": "number"
-          },
-          "netTotalSalesSourceAmountOrZero": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netSourceAmountOrZero": {
-            "type": "number"
-          },
           "bookingContractIdentifier": {
             "type": "string"
           },
@@ -151894,6 +151879,9 @@
           "totalPlatformFeeSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
+          "totalPaymentProcessingFeeSourceAmount": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
           "commissionableSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
@@ -151903,8 +151891,20 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "cancelled": {
+          "agentPayment": {
             "type": "boolean"
+          },
+          "agentSelfManaged": {
+            "type": "boolean"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
+            }
+          },
+          "paymentTransactionIdentifier": {
+            "type": "string"
           }
         }
       },
@@ -152349,8 +152349,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -152360,8 +152360,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -152996,8 +152996,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -153007,8 +153007,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -153148,8 +153148,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   }
                 ],
                 "petInfo": [
@@ -153177,6 +153177,18 @@
           },
           "startDate": "2025-12-24",
           "endDate": "2025-12-27",
+          "sourceTotal": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "internalTotal": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "userSpecifiedCurrencyTotal": {
+            "amount": 1250,
+            "currency": "USD"
+          },
           "beneficiaryList": [
             {
               "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -153208,19 +153220,7 @@
               "netInternalAmount": 450,
               "reconciled": false
             }
-          ],
-          "sourceTotal": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "internalTotal": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "userSpecifiedCurrencyTotal": {
-            "amount": 1250,
-            "currency": "USD"
-          }
+          ]
         },
         "properties": {
           "room": {
@@ -153338,22 +153338,16 @@
             "description": "Check-out date",
             "example": "2025-12-27"
           },
-          "roomNights": {
+          "guests": {
             "type": "integer",
-            "format": "int64"
+            "format": "int32"
           },
           "rateSource": {
             "type": "string"
           },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
-            }
-          },
-          "guests": {
+          "roomNights": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "sourceTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
@@ -153363,6 +153357,12 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
+            }
           }
         },
         "required": [
@@ -153832,14 +153832,14 @@
           "financialBreakdown": {
             "$ref": "#/components/schemas/FinancialBreakdown_SupplierDetails"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "beneficiaryList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Beneficiary_SupplierDetails"
             }
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         }
       },
@@ -154989,8 +154989,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 }
               ],
               "petInfo": [
@@ -155095,8 +155095,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -155543,8 +155543,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -158097,7 +158097,7 @@
               ],
               "createdDate": "2026-01-14T09:30:00",
               "lastUpdate": "2026-02-03T16:45:12",
-              "aggregatedItemDescriptions": [
+              "effectiveDescriptions": [
                 {
                   "description": "This is a longer description in the specified language.",
                   "language": "en",
@@ -158105,7 +158105,7 @@
                   "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                 }
               ],
-              "effectiveDescriptions": [
+              "aggregatedItemDescriptions": [
                 {
                   "description": "This is a longer description in the specified language.",
                   "language": "en",
@@ -160644,8 +160644,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -160655,8 +160655,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "financialBreakdown": {
             "displayPriceQuote": {
@@ -161077,18 +161077,6 @@
               "default": ""
             }
           },
-          "guests": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total guests for this stay"
-          },
-          "rooms": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total rooms for this stay"
-          },
           "hours": {
             "type": "integer",
             "format": "int64",
@@ -161101,6 +161089,18 @@
             "format": "int32",
             "default": "",
             "description": "How many total children for this stay"
+          },
+          "guests": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total guests for this stay"
+          },
+          "rooms": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total rooms for this stay"
           }
         },
         "required": [
@@ -161258,8 +161258,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -161269,8 +161269,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -161753,8 +161753,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -161764,8 +161764,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "financialBreakdown": {
                   "displayPriceQuote": {
@@ -161905,8 +161905,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     }
                   ],
                   "petInfo": [
@@ -162366,6 +162366,208 @@
               "currency": "USD"
             }
           ],
+          "guestUser": {
+            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+            "firstName": "Alexandra",
+            "lastName": "Beaumont",
+            "email": "reservations@thesiamresidences.com",
+            "telephone": "+1 212 555 1212",
+            "profile": {
+              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+              "createdDate": "2026-01-14T09:30:00",
+              "lastUpdate": "2026-02-03T16:45:12",
+              "version": 3,
+              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+              "share": true,
+              "user": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "alexandra@beaumont.com",
+                "phone": "+66212658866",
+                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                "fullName": "Alexandra Beaumont"
+              },
+              "personal": {
+                "gender": "FEMALE",
+                "birthDate": "1985-06-15",
+                "maritalStatus": "MARRIED",
+                "childQuantity": 2,
+                "citizenship": "Thailand",
+                "address1": "123 Petchburi Road",
+                "address2": "Ratchathewi District",
+                "city": "Bangkok",
+                "state": "Bangkok",
+                "postalCode": "10400",
+                "country": "TH",
+                "preferredCurrency": "USD",
+                "language": "en",
+                "contactPerson": [
+                  {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  }
+                ],
+                "petInfo": [
+                  {
+                    "name": "Luna",
+                    "type": "Golden Retriever"
+                  }
+                ]
+              },
+              "preferences": {
+                "propertyLocationPref": "Beachfront",
+                "propertyTypePref": "Luxury Resort",
+                "hotelChainPref": "Mandarin Oriental",
+                "physChalFeaturePref": "Wheelchair accessible rooms",
+                "smokingAllowed": false,
+                "roomLocationPref": "High floor with city view",
+                "bedTypePref": "King bed",
+                "foodSrvcPref": "In-room dining",
+                "guestType": "Business traveler",
+                "mealPref": "Continental breakfast",
+                "cuisinePref": "Thai"
+              }
+            },
+            "fullName": "Alexandra Beaumont"
+          },
+          "ancillaryList": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
           "meetingRooms": [
             {
               "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -162436,8 +162638,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -162447,8 +162649,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -162568,8 +162770,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -162579,8 +162781,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -162700,8 +162902,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -162711,8 +162913,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -162832,8 +163034,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -162843,8 +163045,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -162964,8 +163166,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -162975,8 +163177,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -163096,8 +163298,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -163107,8 +163309,140 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
+          "roomTypeAncillaries": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -163228,8 +163562,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -163239,242 +163573,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "beneficiaryList": [
-            {
-              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-              "accountName": "The Siam Residences, Bangkok",
-              "accountEmail": "reservations@thesiamresidences.com",
-              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-              "amountDue": {
-                "percent": 0.05
-              },
-              "sourceCurrency": "THB",
-              "displayCurrency": "USD",
-              "internalCurrency": "USD",
-              "sourceAmount": 450,
-              "displayAmount": 450,
-              "internalAmount": 450,
-              "sourceAmountRefundModifier": 45,
-              "displayAmountRefundModifier": 45,
-              "internalAmountRefundModifier": 45,
-              "pendingRefunds": [
-                {
-                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45
-                }
-              ],
-              "netSourceAmount": 450,
-              "netDisplayAmount": 450,
-              "netInternalAmount": 450,
-              "reconciled": false
-            }
-          ],
-          "guestUser": {
-            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-            "firstName": "Alexandra",
-            "lastName": "Beaumont",
-            "email": "reservations@thesiamresidences.com",
-            "telephone": "+1 212 555 1212",
-            "profile": {
-              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-              "createdDate": "2026-01-14T09:30:00",
-              "lastUpdate": "2026-02-03T16:45:12",
-              "version": 3,
-              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-              "share": true,
-              "user": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "alexandra@beaumont.com",
-                "phone": "+66212658866",
-                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                "fullName": "Alexandra Beaumont"
-              },
-              "personal": {
-                "gender": "FEMALE",
-                "birthDate": "1985-06-15",
-                "maritalStatus": "MARRIED",
-                "childQuantity": 2,
-                "citizenship": "Thailand",
-                "address1": "123 Petchburi Road",
-                "address2": "Ratchathewi District",
-                "city": "Bangkok",
-                "state": "Bangkok",
-                "postalCode": "10400",
-                "country": "TH",
-                "preferredCurrency": "USD",
-                "language": "en",
-                "contactPerson": [
-                  {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  }
-                ],
-                "petInfo": [
-                  {
-                    "name": "Luna",
-                    "type": "Golden Retriever"
-                  }
-                ]
-              },
-              "preferences": {
-                "propertyLocationPref": "Beachfront",
-                "propertyTypePref": "Luxury Resort",
-                "hotelChainPref": "Mandarin Oriental",
-                "physChalFeaturePref": "Wheelchair accessible rooms",
-                "smokingAllowed": false,
-                "roomLocationPref": "High floor with city view",
-                "bedTypePref": "King bed",
-                "foodSrvcPref": "In-room dining",
-                "guestType": "Business traveler",
-                "mealPref": "Continental breakfast",
-                "cuisinePref": "Thai"
-              }
-            },
-            "fullName": "Alexandra Beaumont"
-          },
-          "ancillaryList": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -163525,142 +163625,6 @@
             }
           ],
           "cancellable": false,
-          "roomTypeAncillaries": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "totalPaymentProcessingFeeSourceAmount": {
-            "amount": 1250,
-            "currency": "USD"
-          },
           "netTotalSalesSourceAmountOrZero": {
             "amount": 1250,
             "currency": "USD"
@@ -163670,6 +163634,10 @@
             "currency": "USD"
           },
           "totalPlatformFeeSourceAmount": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "totalPaymentProcessingFeeSourceAmount": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -163684,7 +163652,39 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "amount": 1250,
             "currency": "USD"
-          }
+          },
+          "beneficiaryList": [
+            {
+              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+              "accountName": "The Siam Residences, Bangkok",
+              "accountEmail": "reservations@thesiamresidences.com",
+              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+              "amountDue": {
+                "percent": 0.05
+              },
+              "sourceCurrency": "THB",
+              "displayCurrency": "USD",
+              "internalCurrency": "USD",
+              "sourceAmount": 450,
+              "displayAmount": 450,
+              "internalAmount": 450,
+              "sourceAmountRefundModifier": 45,
+              "displayAmountRefundModifier": 45,
+              "internalAmountRefundModifier": 45,
+              "pendingRefunds": [
+                {
+                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45
+                }
+              ],
+              "netSourceAmount": 450,
+              "netDisplayAmount": 450,
+              "netInternalAmount": 450,
+              "reconciled": false
+            }
+          ]
         },
         "properties": {
           "id": {
@@ -164100,6 +164100,28 @@
               "default": ""
             }
           },
+          "cancelled": {
+            "type": "boolean"
+          },
+          "rateSource": {
+            "type": "string"
+          },
+          "cancelledOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guestUser": {
+            "$ref": "#/components/schemas/GuestUser_Supplier"
+          },
+          "cancelReason": {
+            "type": "string"
+          },
+          "ancillaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_Supplier"
+            }
+          },
           "meetingRooms": {
             "type": "array",
             "items": {
@@ -164136,38 +164158,50 @@
               "$ref": "#/components/schemas/BookingAncillary_Supplier"
             }
           },
+          "roomTypeAncillaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_Supplier"
+            }
+          },
           "addOns": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BookingAncillary_Supplier"
             }
           },
-          "rateSource": {
+          "cancellationType": {
+            "type": "string",
+            "description": "Reason category for a booking cancellation",
+            "enum": [
+              "DUPLICATE",
+              "CANCELLATION",
+              "NO_SHOW",
+              "CC_INVALID",
+              "CC_INSUFFICIENT",
+              "DISCRETIONARY"
+            ],
+            "default": null
+          },
+          "cancellable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
+          },
+          "displayCurrency": {
             "type": "string"
-          },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary_Supplier"
-            }
-          },
-          "agentPayment": {
-            "type": "boolean"
-          },
-          "guestUser": {
-            "$ref": "#/components/schemas/GuestUser_Supplier"
-          },
-          "ancillaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_Supplier"
-            }
-          },
-          "agentSelfManaged": {
-            "type": "boolean"
           },
           "roomImageUrl": {
             "type": "string"
+          },
+          "netDisplayAmount": {
+            "type": "number"
+          },
+          "netTotalSalesSourceAmountOrZero": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "netSourceAmountOrZero": {
+            "type": "number"
           },
           "hasRefunds": {
             "type": "boolean"
@@ -164183,55 +164217,6 @@
             ],
             "default": null
           },
-          "cancelledOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cancellable": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
-          },
-          "displayCurrency": {
-            "type": "string"
-          },
-          "cancelReason": {
-            "type": "string"
-          },
-          "cancellationType": {
-            "type": "string",
-            "description": "Reason category for a booking cancellation",
-            "enum": [
-              "DUPLICATE",
-              "CANCELLATION",
-              "NO_SHOW",
-              "CC_INVALID",
-              "CC_INSUFFICIENT",
-              "DISCRETIONARY"
-            ],
-            "default": null
-          },
-          "paymentTransactionIdentifier": {
-            "type": "string"
-          },
-          "roomTypeAncillaries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_Supplier"
-            }
-          },
-          "totalPaymentProcessingFeeSourceAmount": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netDisplayAmount": {
-            "type": "number"
-          },
-          "netTotalSalesSourceAmountOrZero": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netSourceAmountOrZero": {
-            "type": "number"
-          },
           "bookingContractIdentifier": {
             "type": "string"
           },
@@ -164244,6 +164229,9 @@
           "totalPlatformFeeSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
+          "totalPaymentProcessingFeeSourceAmount": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
           "commissionableSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
@@ -164253,8 +164241,20 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "cancelled": {
+          "agentPayment": {
             "type": "boolean"
+          },
+          "agentSelfManaged": {
+            "type": "boolean"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary_Supplier"
+            }
+          },
+          "paymentTransactionIdentifier": {
+            "type": "string"
           }
         }
       },
@@ -164699,8 +164699,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -164710,8 +164710,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -165194,8 +165194,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -165205,8 +165205,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -165346,8 +165346,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   }
                 ],
                 "petInfo": [
@@ -165504,16 +165504,16 @@
             "description": "Check-out date",
             "example": "2025-12-27"
           },
-          "roomNights": {
+          "guests": {
             "type": "integer",
-            "format": "int64"
+            "format": "int32"
           },
           "rateSource": {
             "type": "string"
           },
-          "guests": {
+          "roomNights": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "sourceTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
@@ -167327,8 +167327,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 }
               ],
               "petInfo": [
@@ -167561,6 +167561,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -167578,9 +167581,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -167744,8 +167744,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -167755,8 +167755,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -168239,8 +168239,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -168250,8 +168250,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -168391,8 +168391,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         }
                       ],
                       "petInfo": [
@@ -168852,6 +168852,208 @@
                   "currency": "USD"
                 }
               ],
+              "guestUser": {
+                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "reservations@thesiamresidences.com",
+                "telephone": "+1 212 555 1212",
+                "profile": {
+                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                  "createdDate": "2026-01-14T09:30:00",
+                  "lastUpdate": "2026-02-03T16:45:12",
+                  "version": 3,
+                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                  "share": true,
+                  "user": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "alexandra@beaumont.com",
+                    "phone": "+66212658866",
+                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "personal": {
+                    "gender": "FEMALE",
+                    "birthDate": "1985-06-15",
+                    "maritalStatus": "MARRIED",
+                    "childQuantity": 2,
+                    "citizenship": "Thailand",
+                    "address1": "123 Petchburi Road",
+                    "address2": "Ratchathewi District",
+                    "city": "Bangkok",
+                    "state": "Bangkok",
+                    "postalCode": "10400",
+                    "country": "TH",
+                    "preferredCurrency": "USD",
+                    "language": "en",
+                    "contactPerson": [
+                      {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      }
+                    ],
+                    "petInfo": [
+                      {
+                        "name": "Luna",
+                        "type": "Golden Retriever"
+                      }
+                    ]
+                  },
+                  "preferences": {
+                    "propertyLocationPref": "Beachfront",
+                    "propertyTypePref": "Luxury Resort",
+                    "hotelChainPref": "Mandarin Oriental",
+                    "physChalFeaturePref": "Wheelchair accessible rooms",
+                    "smokingAllowed": false,
+                    "roomLocationPref": "High floor with city view",
+                    "bedTypePref": "King bed",
+                    "foodSrvcPref": "In-room dining",
+                    "guestType": "Business traveler",
+                    "mealPref": "Continental breakfast",
+                    "cuisinePref": "Thai"
+                  }
+                },
+                "fullName": "Alexandra Beaumont"
+              },
+              "ancillaryList": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
               "meetingRooms": [
                 {
                   "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -168922,8 +169124,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -168933,8 +169135,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -169054,8 +169256,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -169065,8 +169267,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -169186,8 +169388,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -169197,8 +169399,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -169318,8 +169520,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -169329,8 +169531,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -169450,8 +169652,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -169461,8 +169663,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -169582,8 +169784,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -169593,8 +169795,140 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "roomTypeAncillaries": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -169714,8 +170048,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -169725,242 +170059,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "beneficiaryList": [
-                {
-                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                  "accountName": "The Siam Residences, Bangkok",
-                  "accountEmail": "reservations@thesiamresidences.com",
-                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                  "amountDue": {
-                    "percent": 0.05
-                  },
-                  "sourceCurrency": "THB",
-                  "displayCurrency": "USD",
-                  "internalCurrency": "USD",
-                  "sourceAmount": 450,
-                  "displayAmount": 450,
-                  "internalAmount": 450,
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45,
-                  "pendingRefunds": [
-                    {
-                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45
-                    }
-                  ],
-                  "netSourceAmount": 450,
-                  "netDisplayAmount": 450,
-                  "netInternalAmount": 450,
-                  "reconciled": false
-                }
-              ],
-              "guestUser": {
-                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "reservations@thesiamresidences.com",
-                "telephone": "+1 212 555 1212",
-                "profile": {
-                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                  "createdDate": "2026-01-14T09:30:00",
-                  "lastUpdate": "2026-02-03T16:45:12",
-                  "version": 3,
-                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                  "share": true,
-                  "user": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "alexandra@beaumont.com",
-                    "phone": "+66212658866",
-                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "personal": {
-                    "gender": "FEMALE",
-                    "birthDate": "1985-06-15",
-                    "maritalStatus": "MARRIED",
-                    "childQuantity": 2,
-                    "citizenship": "Thailand",
-                    "address1": "123 Petchburi Road",
-                    "address2": "Ratchathewi District",
-                    "city": "Bangkok",
-                    "state": "Bangkok",
-                    "postalCode": "10400",
-                    "country": "TH",
-                    "preferredCurrency": "USD",
-                    "language": "en",
-                    "contactPerson": [
-                      {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      }
-                    ],
-                    "petInfo": [
-                      {
-                        "name": "Luna",
-                        "type": "Golden Retriever"
-                      }
-                    ]
-                  },
-                  "preferences": {
-                    "propertyLocationPref": "Beachfront",
-                    "propertyTypePref": "Luxury Resort",
-                    "hotelChainPref": "Mandarin Oriental",
-                    "physChalFeaturePref": "Wheelchair accessible rooms",
-                    "smokingAllowed": false,
-                    "roomLocationPref": "High floor with city view",
-                    "bedTypePref": "King bed",
-                    "foodSrvcPref": "In-room dining",
-                    "guestType": "Business traveler",
-                    "mealPref": "Continental breakfast",
-                    "cuisinePref": "Thai"
-                  }
-                },
-                "fullName": "Alexandra Beaumont"
-              },
-              "ancillaryList": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -170011,142 +170111,6 @@
                 }
               ],
               "cancellable": false,
-              "roomTypeAncillaries": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "totalPaymentProcessingFeeSourceAmount": {
-                "amount": 1250,
-                "currency": "USD"
-              },
               "netTotalSalesSourceAmountOrZero": {
                 "amount": 1250,
                 "currency": "USD"
@@ -170156,6 +170120,10 @@
                 "currency": "USD"
               },
               "totalPlatformFeeSourceAmount": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "totalPaymentProcessingFeeSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -170170,7 +170138,39 @@
               "totalSupplierAgencyFeesSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
-              }
+              },
+              "beneficiaryList": [
+                {
+                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                  "accountName": "The Siam Residences, Bangkok",
+                  "accountEmail": "reservations@thesiamresidences.com",
+                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                  "amountDue": {
+                    "percent": 0.05
+                  },
+                  "sourceCurrency": "THB",
+                  "displayCurrency": "USD",
+                  "internalCurrency": "USD",
+                  "sourceAmount": 450,
+                  "displayAmount": 450,
+                  "internalAmount": 450,
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45,
+                  "pendingRefunds": [
+                    {
+                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45
+                    }
+                  ],
+                  "netSourceAmount": 450,
+                  "netDisplayAmount": 450,
+                  "netInternalAmount": 450,
+                  "reconciled": false
+                }
+              ]
             }
           ],
           "number": 0,
@@ -170409,8 +170409,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -170857,8 +170857,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -174056,8 +174056,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "revenueContact": {
             "firstName": "Alexandra",
@@ -174065,8 +174065,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "marketingContact": {
             "firstName": "Alexandra",
@@ -174074,8 +174074,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "reservationDeskStartTime": "10:00",
           "reservationDeskEndTime": "23:00"
@@ -174316,8 +174316,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -174327,8 +174327,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -175221,8 +175221,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -175232,8 +175232,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -176068,8 +176068,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -176079,8 +176079,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -176569,8 +176569,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -176580,8 +176580,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -177079,8 +177079,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -177090,8 +177090,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -177557,8 +177557,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -177568,8 +177568,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -177974,8 +177974,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -177985,8 +177985,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -178575,8 +178575,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -178586,8 +178586,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -180163,8 +180163,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -180174,8 +180174,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -180881,7 +180881,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "inventory.read": "View your inventory & rates.",
               "inventory.write": "Create and update your inventory & rates.",

--- a/schemas/link-manager.json
+++ b/schemas/link-manager.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Create, read, update, and delete shortened URLs with custom slugs for properties, bookings, and external links. Includes Open Graph metadata scraping for external URLs.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#link-manager/tag/shortened-url"
+        "url": "https://api.wink.travel/scalar#link-manager/tag/shortened-url"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Customize the design and appearance of your WinkLinks page.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#link-manager/tag/design"
+        "url": "https://api.wink.travel/scalar#link-manager/tag/design"
       }
     },
     {
@@ -46,7 +46,7 @@
       "description": "Tag WinkLinks entries with categories so your users can filter your content.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#link-manager/tag/tags"
+        "url": "https://api.wink.travel/scalar#link-manager/tag/tags"
       }
     },
     {
@@ -54,7 +54,7 @@
       "description": "Manage your WinkLinks entries.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#link-manager/tag/entries"
+        "url": "https://api.wink.travel/scalar#link-manager/tag/entries"
       }
     }
   ],
@@ -8448,7 +8448,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "marketing.read": "View your marketing & promotions.",
               "marketing.write": "Create and update your marketing & promotions.",

--- a/schemas/partner.json
+++ b/schemas/partner.json
@@ -894,11 +894,11 @@
             "type": "string",
             "description": "When this property's record last changed, ISO-8601 \"YYYY-MM-DDThh:mm:ss\" in UTC.\n\nUse it as the cache key for your Content responses: store it alongside what you fetched, compare on\neach search, and re-fetch only when it has moved. It advances when the property or any inventory item\nbeneath it is added, removed or edited.\n\nA caveat worth knowing before you rely on it for correctness: it tracks the property AGGREGATE, so an\nedit confined to a child entity's prose may not always advance it. Treat a stale read as possible and\nre-sync periodically regardless."
           },
-          "prices": {
+          "roomTypes": {
             "type": "array",
-            "description": "Priced offers, SORTED CHEAPEST FIRST by `total`. `prices[0]` is the property's best available\nprice.",
+            "description": "Offers for this property, grouped by room type, cheapest room first. Search returns the single best\noffer per room type; use Inventory for every rate and occupancy combination.",
             "items": {
-              "$ref": "#/components/schemas/wink.partner.v1.RoomRate"
+              "$ref": "#/components/schemas/wink.partner.v1.RoomTypeOffers"
             }
           },
           "commission": {
@@ -1088,6 +1088,40 @@
         },
         "description": "One delivery URL and what it is scaled to."
       },
+      "wink.partner.v1.RoomTypeOffers": {
+        "type": "object",
+        "properties": {
+          "roomTypeId": {
+            "type": "string",
+            "description": "The room type. Join to Content for the full gallery, amenities and long-form descriptions."
+          },
+          "name": {
+            "type": "string",
+            "description": "The room type's name, in the requested language where a translation exists."
+          },
+          "heroImage": {
+            "description": "A single representative image of the room, so an offer can be rendered without a second call. The\nlowest-sorted published image; unset when the room has none. The complete gallery is in Content.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/wink.partner.v1.Multimedia"
+              }
+            ]
+          },
+          "rates": {
+            "type": "array",
+            "description": "Every offer for this room, BOOKABLE FIRST and cheapest first within each group. On Search that is the\nsingle best offer; on Inventory it is every rate and occupancy combination for the requested dates.\n\nUnavailable offers sort last, never first: they report 0 across all amounts, so ordering purely by\nprice would put \"not priced\" ahead of the cheapest real rate.",
+            "items": {
+              "$ref": "#/components/schemas/wink.partner.v1.RoomRate"
+            }
+          },
+          "sort": {
+            "type": "integer",
+            "description": "The property's own display order for its room types, ascending, when it has expressed one; 0 when it\nhas not. This describes the ROOM, which is why it is here rather than on each rate -- the domain\ndefines it as \"how the room types should be sorted and displayed\".\n\nIt is a merchandising hint, not the delivered order: `room_types` is already ordered by price.",
+            "format": "int32"
+          }
+        },
+        "description": "The offers for one room type, with the room's own details carried once.\n\nThis grouping mirrors the pricing engine's own shape (a room type holding its price configurations) and\nthe way a rate table is actually rendered. It exists because `name` and `hero_image` describe the ROOM,\nnot a rate: carried on RoomRate they were repeated across every rate x occupancy combination, which on\nthe Inventory surface is the whole cross-product for the property."
+      },
       "wink.partner.v1.RoomRate": {
         "type": "object",
         "properties": {
@@ -1095,18 +1129,9 @@
             "type": "string",
             "description": "Room rate identifier. Join to Content for the room type, rate plan (embedded on the master rate),\ndescriptions, images and amenities behind this offer."
           },
-          "name": {
-            "type": "string",
-            "description": "The ROOM TYPE's name, localized — \"Deluxe King Room\" and the like. Enough to label the offer in a\nresult list; the full description, images and amenities are in Content.\n\nIn `user_session.language` when the property has translated it, otherwise English, otherwise whatever\nthe property supplied. A row labelled in the wrong language is still more use than a blank one."
-          },
           "available": {
             "type": "boolean",
             "description": "True if THIS offer, at the requested occupancy, is bookable for the itinerary. Narrower than\n`PropertySearchResult.available`, which is true when ANY offer at the property is. An unavailable offer is\nstill returned rather than dropped, so you can show the traveller why it cannot be booked."
-          },
-          "sort": {
-            "type": "integer",
-            "description": "Ordering hint within the property's offers, ascending.",
-            "format": "int32"
           },
           "startDate": {
             "type": "string",
@@ -1718,11 +1743,11 @@
             "description": "Commission rate your account earns on this property, as a fraction — 0.15 for 15%. A property-channel\nterm, so it holds for every offer below.",
             "format": "double"
           },
-          "prices": {
+          "roomTypes": {
             "type": "array",
-            "description": "EVERY priced offer for the requested stay, SORTED CHEAPEST FIRST by `total`.\n\nThis is where Inventory differs from Search: Search returns the best offer per room type, this returns\nevery rate and occupancy combination the property has for these dates. `prices[0]` is the best available\nprice, the same figure Search would have shown for this property.",
+            "description": "Offers grouped by room type. `room_types[0].rates[0]` is the best available price, the same figure\nSearch would have shown for this property.",
             "items": {
-              "$ref": "#/components/schemas/wink.partner.v1.RoomRate"
+              "$ref": "#/components/schemas/wink.partner.v1.RoomTypeOffers"
             }
           }
         },

--- a/schemas/payment.json
+++ b/schemas/payment.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -34,7 +34,7 @@
       "description": "Beneficiary ledger transaction history.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#payment/tag/ledger"
+        "url": "https://api.wink.travel/scalar#payment/tag/ledger"
       }
     },
     {
@@ -42,7 +42,7 @@
       "description": "Beneficiary payout withdrawal management.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#payment/tag/withdrawal"
+        "url": "https://api.wink.travel/scalar#payment/tag/withdrawal"
       }
     }
   ],
@@ -2407,8 +2407,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -2418,8 +2418,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "commissionable": true,
                             "name": "Archery lesson",
@@ -3054,8 +3054,8 @@
                                 "email": "johnsmith@email.com",
                                 "secondaryEmail": "johnsmith2@email.com",
                                 "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                               },
                               "address": {
                                 "address1": "234 Near da beach",
@@ -3065,8 +3065,8 @@
                                 "county": "Alameda county",
                                 "city": "Bangkok",
                                 "countryCode": "TH",
-                                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                                "country": "United States"
+                                "country": "United States",
+                                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                               },
                               "financialBreakdown": {
                                 "displayPriceQuote": {
@@ -3206,8 +3206,8 @@
                                     "email": "johnsmith@email.com",
                                     "secondaryEmail": "johnsmith2@email.com",
                                     "phoneNumber": "+12125551212",
-                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                    "fullName": "Alexandra Beaumont"
+                                    "fullName": "Alexandra Beaumont",
+                                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                   }
                                 ],
                                 "petInfo": [
@@ -3235,6 +3235,18 @@
                           },
                           "startDate": "2025-12-24",
                           "endDate": "2025-12-27",
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
                           "beneficiaryList": [
                             {
                               "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -3266,19 +3278,7 @@
                               "netInternalAmount": 450,
                               "reconciled": false
                             }
-                          ],
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
+                          ]
                         },
                         "booker": {
                           "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
@@ -3700,6 +3700,208 @@
                             "currency": "USD"
                           }
                         ],
+                        "guestUser": {
+                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "reservations@thesiamresidences.com",
+                          "telephone": "+1 212 555 1212",
+                          "profile": {
+                            "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                            "createdDate": "2026-01-14T09:30:00",
+                            "lastUpdate": "2026-02-03T16:45:12",
+                            "version": 3,
+                            "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                            "share": true,
+                            "user": {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "alexandra@beaumont.com",
+                              "phone": "+66212658866",
+                              "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                              "fullName": "Alexandra Beaumont"
+                            },
+                            "personal": {
+                              "gender": "FEMALE",
+                              "birthDate": "1985-06-15",
+                              "maritalStatus": "MARRIED",
+                              "childQuantity": 2,
+                              "citizenship": "Thailand",
+                              "address1": "123 Petchburi Road",
+                              "address2": "Ratchathewi District",
+                              "city": "Bangkok",
+                              "state": "Bangkok",
+                              "postalCode": "10400",
+                              "country": "TH",
+                              "preferredCurrency": "USD",
+                              "language": "en",
+                              "contactPerson": [
+                                {
+                                  "firstName": "Alexandra",
+                                  "lastName": "Beaumont",
+                                  "email": "johnsmith@email.com",
+                                  "secondaryEmail": "johnsmith2@email.com",
+                                  "phoneNumber": "+12125551212",
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                                }
+                              ],
+                              "petInfo": [
+                                {
+                                  "name": "Luna",
+                                  "type": "Golden Retriever"
+                                }
+                              ]
+                            },
+                            "preferences": {
+                              "propertyLocationPref": "Beachfront",
+                              "propertyTypePref": "Luxury Resort",
+                              "hotelChainPref": "Mandarin Oriental",
+                              "physChalFeaturePref": "Wheelchair accessible rooms",
+                              "smokingAllowed": false,
+                              "roomLocationPref": "High floor with city view",
+                              "bedTypePref": "King bed",
+                              "foodSrvcPref": "In-room dining",
+                              "guestType": "Business traveler",
+                              "mealPref": "Continental breakfast",
+                              "cuisinePref": "Thai"
+                            }
+                          },
+                          "fullName": "Alexandra Beaumont"
+                        },
+                        "ancillaryList": [
+                          {
+                            "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                            "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                            "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                            "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                            "name": "Thai Massage Spa Treatment",
+                            "pricingType": "PER_USE",
+                            "type": "ADD_ON",
+                            "price": {
+                              "sourceToUserCurrencyQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "sourceToInternalCurrencyQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "userSpecifiedCurrencyBaseTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "sourceBaseTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "internalBaseTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "userSpecifiedCurrencyPromotionalModifier": -40,
+                              "sourcePromotionalModifier": -40,
+                              "internalPromotionalModifier": -40,
+                              "userSpecifiedCurrencyPremiumModifier": 40,
+                              "sourcePremiumModifier": 40,
+                              "internalPremiumModifier": 40,
+                              "userSpecifiedCurrencyChannelModifier": -10,
+                              "sourceChannelModifier": -10,
+                              "internalChannelModifier": -10,
+                              "quantity": 1,
+                              "sourceTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "internalTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "userSpecifiedCurrencyTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              }
+                            },
+                            "startDate": "2017-12-22T03:07:58.742+0000",
+                            "endDate": "2017-12-22T08:07:58.742+0000",
+                            "attendees": 2,
+                            "imageIdentifier": "cloudinary-image-1",
+                            "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                            "localizedName": "Plass 1",
+                            "localizedDescription": "place-1",
+                            "contact": {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            },
+                            "address": {
+                              "address1": "234 Near da beach",
+                              "address2": "Pebble #5001",
+                              "state": "CA",
+                              "postalCode": "90210",
+                              "county": "Alameda county",
+                              "city": "Bangkok",
+                              "countryCode": "TH",
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                            },
+                            "financialBreakdown": {
+                              "displayPriceQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "internalPriceQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "beneficiaryList": [
+                                {
+                                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                  "accountName": "The Siam Residences, Bangkok",
+                                  "accountEmail": "reservations@thesiamresidences.com",
+                                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                  "amountDue": {
+                                    "percent": 0.05
+                                  },
+                                  "sourceCurrency": "THB",
+                                  "displayCurrency": "USD",
+                                  "internalCurrency": "USD",
+                                  "sourceAmount": 450,
+                                  "displayAmount": 450,
+                                  "internalAmount": 450,
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45,
+                                  "pendingRefunds": [
+                                    {
+                                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                      "sourceAmountRefundModifier": 45,
+                                      "displayAmountRefundModifier": 45,
+                                      "internalAmountRefundModifier": 45
+                                    }
+                                  ],
+                                  "netSourceAmount": 450,
+                                  "netDisplayAmount": 450,
+                                  "netInternalAmount": 450,
+                                  "reconciled": false
+                                }
+                              ]
+                            }
+                          }
+                        ],
                         "meetingRooms": [
                           {
                             "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -3770,8 +3972,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -3781,8 +3983,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -3902,8 +4104,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -3913,8 +4115,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -4034,8 +4236,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -4045,8 +4247,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -4166,8 +4368,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -4177,8 +4379,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -4298,8 +4500,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -4309,8 +4511,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -4430,8 +4632,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -4441,8 +4643,140 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                            },
+                            "financialBreakdown": {
+                              "displayPriceQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "internalPriceQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "beneficiaryList": [
+                                {
+                                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                  "accountName": "The Siam Residences, Bangkok",
+                                  "accountEmail": "reservations@thesiamresidences.com",
+                                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                  "amountDue": {
+                                    "percent": 0.05
+                                  },
+                                  "sourceCurrency": "THB",
+                                  "displayCurrency": "USD",
+                                  "internalCurrency": "USD",
+                                  "sourceAmount": 450,
+                                  "displayAmount": 450,
+                                  "internalAmount": 450,
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45,
+                                  "pendingRefunds": [
+                                    {
+                                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                      "sourceAmountRefundModifier": 45,
+                                      "displayAmountRefundModifier": 45,
+                                      "internalAmountRefundModifier": 45
+                                    }
+                                  ],
+                                  "netSourceAmount": 450,
+                                  "netDisplayAmount": 450,
+                                  "netInternalAmount": 450,
+                                  "reconciled": false
+                                }
+                              ]
+                            }
+                          }
+                        ],
+                        "roomTypeAncillaries": [
+                          {
+                            "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                            "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                            "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                            "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                            "name": "Thai Massage Spa Treatment",
+                            "pricingType": "PER_USE",
+                            "type": "ADD_ON",
+                            "price": {
+                              "sourceToUserCurrencyQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "sourceToInternalCurrencyQuote": {
+                                "source": "USD",
+                                "target": "THB",
+                                "exchangeRate": 33.5,
+                                "timestamp": 1705233000000
+                              },
+                              "userSpecifiedCurrencyBaseTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "sourceBaseTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "internalBaseTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "userSpecifiedCurrencyPromotionalModifier": -40,
+                              "sourcePromotionalModifier": -40,
+                              "internalPromotionalModifier": -40,
+                              "userSpecifiedCurrencyPremiumModifier": 40,
+                              "sourcePremiumModifier": 40,
+                              "internalPremiumModifier": 40,
+                              "userSpecifiedCurrencyChannelModifier": -10,
+                              "sourceChannelModifier": -10,
+                              "internalChannelModifier": -10,
+                              "quantity": 1,
+                              "sourceTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "internalTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              },
+                              "userSpecifiedCurrencyTotal": {
+                                "amount": 1250,
+                                "currency": "USD"
+                              }
+                            },
+                            "startDate": "2017-12-22T03:07:58.742+0000",
+                            "endDate": "2017-12-22T08:07:58.742+0000",
+                            "attendees": 2,
+                            "imageIdentifier": "cloudinary-image-1",
+                            "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                            "localizedName": "Plass 1",
+                            "localizedDescription": "place-1",
+                            "contact": {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            },
+                            "address": {
+                              "address1": "234 Near da beach",
+                              "address2": "Pebble #5001",
+                              "state": "CA",
+                              "postalCode": "90210",
+                              "county": "Alameda county",
+                              "city": "Bangkok",
+                              "countryCode": "TH",
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -4562,8 +4896,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -4573,242 +4907,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
-                            },
-                            "financialBreakdown": {
-                              "displayPriceQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "internalPriceQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "beneficiaryList": [
-                                {
-                                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                  "accountName": "The Siam Residences, Bangkok",
-                                  "accountEmail": "reservations@thesiamresidences.com",
-                                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                  "amountDue": {
-                                    "percent": 0.05
-                                  },
-                                  "sourceCurrency": "THB",
-                                  "displayCurrency": "USD",
-                                  "internalCurrency": "USD",
-                                  "sourceAmount": 450,
-                                  "displayAmount": 450,
-                                  "internalAmount": 450,
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45,
-                                  "pendingRefunds": [
-                                    {
-                                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                      "sourceAmountRefundModifier": 45,
-                                      "displayAmountRefundModifier": 45,
-                                      "internalAmountRefundModifier": 45
-                                    }
-                                  ],
-                                  "netSourceAmount": 450,
-                                  "netDisplayAmount": 450,
-                                  "netInternalAmount": 450,
-                                  "reconciled": false
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ],
-                        "guestUser": {
-                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "reservations@thesiamresidences.com",
-                          "telephone": "+1 212 555 1212",
-                          "profile": {
-                            "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                            "createdDate": "2026-01-14T09:30:00",
-                            "lastUpdate": "2026-02-03T16:45:12",
-                            "version": 3,
-                            "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                            "share": true,
-                            "user": {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "alexandra@beaumont.com",
-                              "phone": "+66212658866",
-                              "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                              "fullName": "Alexandra Beaumont"
-                            },
-                            "personal": {
-                              "gender": "FEMALE",
-                              "birthDate": "1985-06-15",
-                              "maritalStatus": "MARRIED",
-                              "childQuantity": 2,
-                              "citizenship": "Thailand",
-                              "address1": "123 Petchburi Road",
-                              "address2": "Ratchathewi District",
-                              "city": "Bangkok",
-                              "state": "Bangkok",
-                              "postalCode": "10400",
-                              "country": "TH",
-                              "preferredCurrency": "USD",
-                              "language": "en",
-                              "contactPerson": [
-                                {
-                                  "firstName": "Alexandra",
-                                  "lastName": "Beaumont",
-                                  "email": "johnsmith@email.com",
-                                  "secondaryEmail": "johnsmith2@email.com",
-                                  "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
-                                }
-                              ],
-                              "petInfo": [
-                                {
-                                  "name": "Luna",
-                                  "type": "Golden Retriever"
-                                }
-                              ]
-                            },
-                            "preferences": {
-                              "propertyLocationPref": "Beachfront",
-                              "propertyTypePref": "Luxury Resort",
-                              "hotelChainPref": "Mandarin Oriental",
-                              "physChalFeaturePref": "Wheelchair accessible rooms",
-                              "smokingAllowed": false,
-                              "roomLocationPref": "High floor with city view",
-                              "bedTypePref": "King bed",
-                              "foodSrvcPref": "In-room dining",
-                              "guestType": "Business traveler",
-                              "mealPref": "Continental breakfast",
-                              "cuisinePref": "Thai"
-                            }
-                          },
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "ancillaryList": [
-                          {
-                            "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                            "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                            "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                            "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                            "name": "Thai Massage Spa Treatment",
-                            "pricingType": "PER_USE",
-                            "type": "ADD_ON",
-                            "price": {
-                              "sourceToUserCurrencyQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "sourceToInternalCurrencyQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "userSpecifiedCurrencyBaseTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "sourceBaseTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "internalBaseTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "userSpecifiedCurrencyPromotionalModifier": -40,
-                              "sourcePromotionalModifier": -40,
-                              "internalPromotionalModifier": -40,
-                              "userSpecifiedCurrencyPremiumModifier": 40,
-                              "sourcePremiumModifier": 40,
-                              "internalPremiumModifier": 40,
-                              "userSpecifiedCurrencyChannelModifier": -10,
-                              "sourceChannelModifier": -10,
-                              "internalChannelModifier": -10,
-                              "quantity": 1,
-                              "sourceTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "internalTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "userSpecifiedCurrencyTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              }
-                            },
-                            "startDate": "2017-12-22T03:07:58.742+0000",
-                            "endDate": "2017-12-22T08:07:58.742+0000",
-                            "attendees": 2,
-                            "imageIdentifier": "cloudinary-image-1",
-                            "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                            "localizedName": "Plass 1",
-                            "localizedDescription": "place-1",
-                            "contact": {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            },
-                            "address": {
-                              "address1": "234 Near da beach",
-                              "address2": "Pebble #5001",
-                              "state": "CA",
-                              "postalCode": "90210",
-                              "county": "Alameda county",
-                              "city": "Bangkok",
-                              "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -4859,142 +4959,6 @@
                           }
                         ],
                         "cancellable": false,
-                        "roomTypeAncillaries": [
-                          {
-                            "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                            "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                            "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                            "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                            "name": "Thai Massage Spa Treatment",
-                            "pricingType": "PER_USE",
-                            "type": "ADD_ON",
-                            "price": {
-                              "sourceToUserCurrencyQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "sourceToInternalCurrencyQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "userSpecifiedCurrencyBaseTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "sourceBaseTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "internalBaseTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "userSpecifiedCurrencyPromotionalModifier": -40,
-                              "sourcePromotionalModifier": -40,
-                              "internalPromotionalModifier": -40,
-                              "userSpecifiedCurrencyPremiumModifier": 40,
-                              "sourcePremiumModifier": 40,
-                              "internalPremiumModifier": 40,
-                              "userSpecifiedCurrencyChannelModifier": -10,
-                              "sourceChannelModifier": -10,
-                              "internalChannelModifier": -10,
-                              "quantity": 1,
-                              "sourceTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "internalTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              },
-                              "userSpecifiedCurrencyTotal": {
-                                "amount": 1250,
-                                "currency": "USD"
-                              }
-                            },
-                            "startDate": "2017-12-22T03:07:58.742+0000",
-                            "endDate": "2017-12-22T08:07:58.742+0000",
-                            "attendees": 2,
-                            "imageIdentifier": "cloudinary-image-1",
-                            "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                            "localizedName": "Plass 1",
-                            "localizedDescription": "place-1",
-                            "contact": {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            },
-                            "address": {
-                              "address1": "234 Near da beach",
-                              "address2": "Pebble #5001",
-                              "state": "CA",
-                              "postalCode": "90210",
-                              "county": "Alameda county",
-                              "city": "Bangkok",
-                              "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
-                            },
-                            "financialBreakdown": {
-                              "displayPriceQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "internalPriceQuote": {
-                                "source": "USD",
-                                "target": "THB",
-                                "exchangeRate": 33.5,
-                                "timestamp": 1705233000000
-                              },
-                              "beneficiaryList": [
-                                {
-                                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                  "accountName": "The Siam Residences, Bangkok",
-                                  "accountEmail": "reservations@thesiamresidences.com",
-                                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                  "amountDue": {
-                                    "percent": 0.05
-                                  },
-                                  "sourceCurrency": "THB",
-                                  "displayCurrency": "USD",
-                                  "internalCurrency": "USD",
-                                  "sourceAmount": 450,
-                                  "displayAmount": 450,
-                                  "internalAmount": 450,
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45,
-                                  "pendingRefunds": [
-                                    {
-                                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                      "sourceAmountRefundModifier": 45,
-                                      "displayAmountRefundModifier": 45,
-                                      "internalAmountRefundModifier": 45
-                                    }
-                                  ],
-                                  "netSourceAmount": 450,
-                                  "netDisplayAmount": 450,
-                                  "netInternalAmount": 450,
-                                  "reconciled": false
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "totalPaymentProcessingFeeSourceAmount": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
                         "netTotalSalesSourceAmountOrZero": {
                           "amount": 1250,
                           "currency": "USD"
@@ -5004,6 +4968,10 @@
                           "currency": "USD"
                         },
                         "totalPlatformFeeSourceAmount": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "totalPaymentProcessingFeeSourceAmount": {
                           "amount": 1250,
                           "currency": "USD"
                         },
@@ -5018,7 +4986,39 @@
                         "totalSupplierAgencyFeesSourceAmount": {
                           "amount": 1250,
                           "currency": "USD"
-                        }
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
                       }
                     ],
                     "number": 0,
@@ -6151,8 +6151,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -6162,8 +6162,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "financialBreakdown": {
             "displayPriceQuote": {
@@ -6910,8 +6910,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -6921,8 +6921,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "commissionable": true,
                     "name": "Archery lesson",
@@ -7557,8 +7557,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -7568,8 +7568,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -7709,8 +7709,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           }
                         ],
                         "petInfo": [
@@ -7738,6 +7738,18 @@
                   },
                   "startDate": "2025-12-24",
                   "endDate": "2025-12-27",
+                  "sourceTotal": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "internalTotal": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "userSpecifiedCurrencyTotal": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
                   "beneficiaryList": [
                     {
                       "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -7769,19 +7781,7 @@
                       "netInternalAmount": 450,
                       "reconciled": false
                     }
-                  ],
-                  "sourceTotal": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "internalTotal": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
-                  "userSpecifiedCurrencyTotal": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  }
+                  ]
                 },
                 "booker": {
                   "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
@@ -8203,6 +8203,208 @@
                     "currency": "USD"
                   }
                 ],
+                "guestUser": {
+                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                  "firstName": "Alexandra",
+                  "lastName": "Beaumont",
+                  "email": "reservations@thesiamresidences.com",
+                  "telephone": "+1 212 555 1212",
+                  "profile": {
+                    "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                    "createdDate": "2026-01-14T09:30:00",
+                    "lastUpdate": "2026-02-03T16:45:12",
+                    "version": 3,
+                    "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "share": true,
+                    "user": {
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "alexandra@beaumont.com",
+                      "phone": "+66212658866",
+                      "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                      "fullName": "Alexandra Beaumont"
+                    },
+                    "personal": {
+                      "gender": "FEMALE",
+                      "birthDate": "1985-06-15",
+                      "maritalStatus": "MARRIED",
+                      "childQuantity": 2,
+                      "citizenship": "Thailand",
+                      "address1": "123 Petchburi Road",
+                      "address2": "Ratchathewi District",
+                      "city": "Bangkok",
+                      "state": "Bangkok",
+                      "postalCode": "10400",
+                      "country": "TH",
+                      "preferredCurrency": "USD",
+                      "language": "en",
+                      "contactPerson": [
+                        {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        }
+                      ],
+                      "petInfo": [
+                        {
+                          "name": "Luna",
+                          "type": "Golden Retriever"
+                        }
+                      ]
+                    },
+                    "preferences": {
+                      "propertyLocationPref": "Beachfront",
+                      "propertyTypePref": "Luxury Resort",
+                      "hotelChainPref": "Mandarin Oriental",
+                      "physChalFeaturePref": "Wheelchair accessible rooms",
+                      "smokingAllowed": false,
+                      "roomLocationPref": "High floor with city view",
+                      "bedTypePref": "King bed",
+                      "foodSrvcPref": "In-room dining",
+                      "guestType": "Business traveler",
+                      "mealPref": "Continental breakfast",
+                      "cuisinePref": "Thai"
+                    }
+                  },
+                  "fullName": "Alexandra Beaumont"
+                },
+                "ancillaryList": [
+                  {
+                    "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                    "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                    "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                    "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                    "name": "Thai Massage Spa Treatment",
+                    "pricingType": "PER_USE",
+                    "type": "ADD_ON",
+                    "price": {
+                      "sourceToUserCurrencyQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "sourceToInternalCurrencyQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "userSpecifiedCurrencyBaseTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "sourceBaseTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "internalBaseTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "userSpecifiedCurrencyPromotionalModifier": -40,
+                      "sourcePromotionalModifier": -40,
+                      "internalPromotionalModifier": -40,
+                      "userSpecifiedCurrencyPremiumModifier": 40,
+                      "sourcePremiumModifier": 40,
+                      "internalPremiumModifier": 40,
+                      "userSpecifiedCurrencyChannelModifier": -10,
+                      "sourceChannelModifier": -10,
+                      "internalChannelModifier": -10,
+                      "quantity": 1,
+                      "sourceTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "internalTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "userSpecifiedCurrencyTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      }
+                    },
+                    "startDate": "2017-12-22T03:07:58.742+0000",
+                    "endDate": "2017-12-22T08:07:58.742+0000",
+                    "attendees": 2,
+                    "imageIdentifier": "cloudinary-image-1",
+                    "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                    "localizedName": "Plass 1",
+                    "localizedDescription": "place-1",
+                    "contact": {
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "johnsmith@email.com",
+                      "secondaryEmail": "johnsmith2@email.com",
+                      "phoneNumber": "+12125551212",
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                    },
+                    "address": {
+                      "address1": "234 Near da beach",
+                      "address2": "Pebble #5001",
+                      "state": "CA",
+                      "postalCode": "90210",
+                      "county": "Alameda county",
+                      "city": "Bangkok",
+                      "countryCode": "TH",
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                    },
+                    "financialBreakdown": {
+                      "displayPriceQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "internalPriceQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
+                    }
+                  }
+                ],
                 "meetingRooms": [
                   {
                     "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -8273,8 +8475,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -8284,8 +8486,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -8405,8 +8607,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -8416,8 +8618,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -8537,8 +8739,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -8548,8 +8750,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -8669,8 +8871,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -8680,8 +8882,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -8801,8 +9003,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -8812,8 +9014,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -8933,8 +9135,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -8944,8 +9146,140 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                    },
+                    "financialBreakdown": {
+                      "displayPriceQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "internalPriceQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "roomTypeAncillaries": [
+                  {
+                    "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                    "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                    "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                    "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                    "name": "Thai Massage Spa Treatment",
+                    "pricingType": "PER_USE",
+                    "type": "ADD_ON",
+                    "price": {
+                      "sourceToUserCurrencyQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "sourceToInternalCurrencyQuote": {
+                        "source": "USD",
+                        "target": "THB",
+                        "exchangeRate": 33.5,
+                        "timestamp": 1705233000000
+                      },
+                      "userSpecifiedCurrencyBaseTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "sourceBaseTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "internalBaseTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "userSpecifiedCurrencyPromotionalModifier": -40,
+                      "sourcePromotionalModifier": -40,
+                      "internalPromotionalModifier": -40,
+                      "userSpecifiedCurrencyPremiumModifier": 40,
+                      "sourcePremiumModifier": 40,
+                      "internalPremiumModifier": 40,
+                      "userSpecifiedCurrencyChannelModifier": -10,
+                      "sourceChannelModifier": -10,
+                      "internalChannelModifier": -10,
+                      "quantity": 1,
+                      "sourceTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "internalTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "userSpecifiedCurrencyTotal": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      }
+                    },
+                    "startDate": "2017-12-22T03:07:58.742+0000",
+                    "endDate": "2017-12-22T08:07:58.742+0000",
+                    "attendees": 2,
+                    "imageIdentifier": "cloudinary-image-1",
+                    "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                    "localizedName": "Plass 1",
+                    "localizedDescription": "place-1",
+                    "contact": {
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "johnsmith@email.com",
+                      "secondaryEmail": "johnsmith2@email.com",
+                      "phoneNumber": "+12125551212",
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                    },
+                    "address": {
+                      "address1": "234 Near da beach",
+                      "address2": "Pebble #5001",
+                      "state": "CA",
+                      "postalCode": "90210",
+                      "county": "Alameda county",
+                      "city": "Bangkok",
+                      "countryCode": "TH",
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -9065,8 +9399,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -9076,242 +9410,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
-                    },
-                    "financialBreakdown": {
-                      "displayPriceQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "internalPriceQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ],
-                "guestUser": {
-                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                  "firstName": "Alexandra",
-                  "lastName": "Beaumont",
-                  "email": "reservations@thesiamresidences.com",
-                  "telephone": "+1 212 555 1212",
-                  "profile": {
-                    "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                    "createdDate": "2026-01-14T09:30:00",
-                    "lastUpdate": "2026-02-03T16:45:12",
-                    "version": 3,
-                    "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "share": true,
-                    "user": {
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "alexandra@beaumont.com",
-                      "phone": "+66212658866",
-                      "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "personal": {
-                      "gender": "FEMALE",
-                      "birthDate": "1985-06-15",
-                      "maritalStatus": "MARRIED",
-                      "childQuantity": 2,
-                      "citizenship": "Thailand",
-                      "address1": "123 Petchburi Road",
-                      "address2": "Ratchathewi District",
-                      "city": "Bangkok",
-                      "state": "Bangkok",
-                      "postalCode": "10400",
-                      "country": "TH",
-                      "preferredCurrency": "USD",
-                      "language": "en",
-                      "contactPerson": [
-                        {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        }
-                      ],
-                      "petInfo": [
-                        {
-                          "name": "Luna",
-                          "type": "Golden Retriever"
-                        }
-                      ]
-                    },
-                    "preferences": {
-                      "propertyLocationPref": "Beachfront",
-                      "propertyTypePref": "Luxury Resort",
-                      "hotelChainPref": "Mandarin Oriental",
-                      "physChalFeaturePref": "Wheelchair accessible rooms",
-                      "smokingAllowed": false,
-                      "roomLocationPref": "High floor with city view",
-                      "bedTypePref": "King bed",
-                      "foodSrvcPref": "In-room dining",
-                      "guestType": "Business traveler",
-                      "mealPref": "Continental breakfast",
-                      "cuisinePref": "Thai"
-                    }
-                  },
-                  "fullName": "Alexandra Beaumont"
-                },
-                "ancillaryList": [
-                  {
-                    "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                    "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                    "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                    "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                    "name": "Thai Massage Spa Treatment",
-                    "pricingType": "PER_USE",
-                    "type": "ADD_ON",
-                    "price": {
-                      "sourceToUserCurrencyQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "sourceToInternalCurrencyQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "userSpecifiedCurrencyBaseTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "sourceBaseTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "internalBaseTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "userSpecifiedCurrencyPromotionalModifier": -40,
-                      "sourcePromotionalModifier": -40,
-                      "internalPromotionalModifier": -40,
-                      "userSpecifiedCurrencyPremiumModifier": 40,
-                      "sourcePremiumModifier": 40,
-                      "internalPremiumModifier": 40,
-                      "userSpecifiedCurrencyChannelModifier": -10,
-                      "sourceChannelModifier": -10,
-                      "internalChannelModifier": -10,
-                      "quantity": 1,
-                      "sourceTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "internalTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "userSpecifiedCurrencyTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      }
-                    },
-                    "startDate": "2017-12-22T03:07:58.742+0000",
-                    "endDate": "2017-12-22T08:07:58.742+0000",
-                    "attendees": 2,
-                    "imageIdentifier": "cloudinary-image-1",
-                    "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                    "localizedName": "Plass 1",
-                    "localizedDescription": "place-1",
-                    "contact": {
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "johnsmith@email.com",
-                      "secondaryEmail": "johnsmith2@email.com",
-                      "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "address": {
-                      "address1": "234 Near da beach",
-                      "address2": "Pebble #5001",
-                      "state": "CA",
-                      "postalCode": "90210",
-                      "county": "Alameda county",
-                      "city": "Bangkok",
-                      "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -9362,142 +9462,6 @@
                   }
                 ],
                 "cancellable": false,
-                "roomTypeAncillaries": [
-                  {
-                    "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                    "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                    "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                    "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                    "name": "Thai Massage Spa Treatment",
-                    "pricingType": "PER_USE",
-                    "type": "ADD_ON",
-                    "price": {
-                      "sourceToUserCurrencyQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "sourceToInternalCurrencyQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "userSpecifiedCurrencyBaseTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "sourceBaseTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "internalBaseTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "userSpecifiedCurrencyPromotionalModifier": -40,
-                      "sourcePromotionalModifier": -40,
-                      "internalPromotionalModifier": -40,
-                      "userSpecifiedCurrencyPremiumModifier": 40,
-                      "sourcePremiumModifier": 40,
-                      "internalPremiumModifier": 40,
-                      "userSpecifiedCurrencyChannelModifier": -10,
-                      "sourceChannelModifier": -10,
-                      "internalChannelModifier": -10,
-                      "quantity": 1,
-                      "sourceTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "internalTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
-                      "userSpecifiedCurrencyTotal": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      }
-                    },
-                    "startDate": "2017-12-22T03:07:58.742+0000",
-                    "endDate": "2017-12-22T08:07:58.742+0000",
-                    "attendees": 2,
-                    "imageIdentifier": "cloudinary-image-1",
-                    "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                    "localizedName": "Plass 1",
-                    "localizedDescription": "place-1",
-                    "contact": {
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "johnsmith@email.com",
-                      "secondaryEmail": "johnsmith2@email.com",
-                      "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "address": {
-                      "address1": "234 Near da beach",
-                      "address2": "Pebble #5001",
-                      "state": "CA",
-                      "postalCode": "90210",
-                      "county": "Alameda county",
-                      "city": "Bangkok",
-                      "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
-                    },
-                    "financialBreakdown": {
-                      "displayPriceQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "internalPriceQuote": {
-                        "source": "USD",
-                        "target": "THB",
-                        "exchangeRate": 33.5,
-                        "timestamp": 1705233000000
-                      },
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "totalPaymentProcessingFeeSourceAmount": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
                 "netTotalSalesSourceAmountOrZero": {
                   "amount": 1250,
                   "currency": "USD"
@@ -9507,6 +9471,10 @@
                   "currency": "USD"
                 },
                 "totalPlatformFeeSourceAmount": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "totalPaymentProcessingFeeSourceAmount": {
                   "amount": 1250,
                   "currency": "USD"
                 },
@@ -9521,7 +9489,39 @@
                 "totalSupplierAgencyFeesSourceAmount": {
                   "amount": 1250,
                   "currency": "USD"
-                }
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
               }
             ],
             "number": 0,
@@ -9614,18 +9614,6 @@
               "default": ""
             }
           },
-          "guests": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total guests for this stay"
-          },
-          "rooms": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total rooms for this stay"
-          },
           "hours": {
             "type": "integer",
             "format": "int64",
@@ -9638,6 +9626,18 @@
             "format": "int32",
             "default": "",
             "description": "How many total children for this stay"
+          },
+          "guests": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total guests for this stay"
+          },
+          "rooms": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total rooms for this stay"
           }
         },
         "required": [
@@ -9860,8 +9860,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -9871,8 +9871,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -10507,8 +10507,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -10518,8 +10518,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "financialBreakdown": {
                   "displayPriceQuote": {
@@ -10659,8 +10659,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     }
                   ],
                   "petInfo": [
@@ -10688,6 +10688,18 @@
             },
             "startDate": "2025-12-24",
             "endDate": "2025-12-27",
+            "sourceTotal": {
+              "amount": 1250,
+              "currency": "USD"
+            },
+            "internalTotal": {
+              "amount": 1250,
+              "currency": "USD"
+            },
+            "userSpecifiedCurrencyTotal": {
+              "amount": 1250,
+              "currency": "USD"
+            },
             "beneficiaryList": [
               {
                 "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -10719,19 +10731,7 @@
                 "netInternalAmount": 450,
                 "reconciled": false
               }
-            ],
-            "sourceTotal": {
-              "amount": 1250,
-              "currency": "USD"
-            },
-            "internalTotal": {
-              "amount": 1250,
-              "currency": "USD"
-            },
-            "userSpecifiedCurrencyTotal": {
-              "amount": 1250,
-              "currency": "USD"
-            }
+            ]
           },
           "booker": {
             "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
@@ -11153,6 +11153,208 @@
               "currency": "USD"
             }
           ],
+          "guestUser": {
+            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+            "firstName": "Alexandra",
+            "lastName": "Beaumont",
+            "email": "reservations@thesiamresidences.com",
+            "telephone": "+1 212 555 1212",
+            "profile": {
+              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+              "createdDate": "2026-01-14T09:30:00",
+              "lastUpdate": "2026-02-03T16:45:12",
+              "version": 3,
+              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+              "share": true,
+              "user": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "alexandra@beaumont.com",
+                "phone": "+66212658866",
+                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                "fullName": "Alexandra Beaumont"
+              },
+              "personal": {
+                "gender": "FEMALE",
+                "birthDate": "1985-06-15",
+                "maritalStatus": "MARRIED",
+                "childQuantity": 2,
+                "citizenship": "Thailand",
+                "address1": "123 Petchburi Road",
+                "address2": "Ratchathewi District",
+                "city": "Bangkok",
+                "state": "Bangkok",
+                "postalCode": "10400",
+                "country": "TH",
+                "preferredCurrency": "USD",
+                "language": "en",
+                "contactPerson": [
+                  {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  }
+                ],
+                "petInfo": [
+                  {
+                    "name": "Luna",
+                    "type": "Golden Retriever"
+                  }
+                ]
+              },
+              "preferences": {
+                "propertyLocationPref": "Beachfront",
+                "propertyTypePref": "Luxury Resort",
+                "hotelChainPref": "Mandarin Oriental",
+                "physChalFeaturePref": "Wheelchair accessible rooms",
+                "smokingAllowed": false,
+                "roomLocationPref": "High floor with city view",
+                "bedTypePref": "King bed",
+                "foodSrvcPref": "In-room dining",
+                "guestType": "Business traveler",
+                "mealPref": "Continental breakfast",
+                "cuisinePref": "Thai"
+              }
+            },
+            "fullName": "Alexandra Beaumont"
+          },
+          "ancillaryList": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
           "meetingRooms": [
             {
               "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -11223,8 +11425,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -11234,8 +11436,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -11355,8 +11557,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -11366,8 +11568,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -11487,8 +11689,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -11498,8 +11700,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -11619,8 +11821,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -11630,8 +11832,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -11751,8 +11953,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -11762,8 +11964,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -11883,8 +12085,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -11894,8 +12096,140 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
+          "roomTypeAncillaries": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -12015,8 +12349,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -12026,242 +12360,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "beneficiaryList": [
-            {
-              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-              "accountName": "The Siam Residences, Bangkok",
-              "accountEmail": "reservations@thesiamresidences.com",
-              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-              "amountDue": {
-                "percent": 0.05
-              },
-              "sourceCurrency": "THB",
-              "displayCurrency": "USD",
-              "internalCurrency": "USD",
-              "sourceAmount": 450,
-              "displayAmount": 450,
-              "internalAmount": 450,
-              "sourceAmountRefundModifier": 45,
-              "displayAmountRefundModifier": 45,
-              "internalAmountRefundModifier": 45,
-              "pendingRefunds": [
-                {
-                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45
-                }
-              ],
-              "netSourceAmount": 450,
-              "netDisplayAmount": 450,
-              "netInternalAmount": 450,
-              "reconciled": false
-            }
-          ],
-          "guestUser": {
-            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-            "firstName": "Alexandra",
-            "lastName": "Beaumont",
-            "email": "reservations@thesiamresidences.com",
-            "telephone": "+1 212 555 1212",
-            "profile": {
-              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-              "createdDate": "2026-01-14T09:30:00",
-              "lastUpdate": "2026-02-03T16:45:12",
-              "version": 3,
-              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-              "share": true,
-              "user": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "alexandra@beaumont.com",
-                "phone": "+66212658866",
-                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                "fullName": "Alexandra Beaumont"
-              },
-              "personal": {
-                "gender": "FEMALE",
-                "birthDate": "1985-06-15",
-                "maritalStatus": "MARRIED",
-                "childQuantity": 2,
-                "citizenship": "Thailand",
-                "address1": "123 Petchburi Road",
-                "address2": "Ratchathewi District",
-                "city": "Bangkok",
-                "state": "Bangkok",
-                "postalCode": "10400",
-                "country": "TH",
-                "preferredCurrency": "USD",
-                "language": "en",
-                "contactPerson": [
-                  {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  }
-                ],
-                "petInfo": [
-                  {
-                    "name": "Luna",
-                    "type": "Golden Retriever"
-                  }
-                ]
-              },
-              "preferences": {
-                "propertyLocationPref": "Beachfront",
-                "propertyTypePref": "Luxury Resort",
-                "hotelChainPref": "Mandarin Oriental",
-                "physChalFeaturePref": "Wheelchair accessible rooms",
-                "smokingAllowed": false,
-                "roomLocationPref": "High floor with city view",
-                "bedTypePref": "King bed",
-                "foodSrvcPref": "In-room dining",
-                "guestType": "Business traveler",
-                "mealPref": "Continental breakfast",
-                "cuisinePref": "Thai"
-              }
-            },
-            "fullName": "Alexandra Beaumont"
-          },
-          "ancillaryList": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -12312,142 +12412,6 @@
             }
           ],
           "cancellable": false,
-          "roomTypeAncillaries": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "totalPaymentProcessingFeeSourceAmount": {
-            "amount": 1250,
-            "currency": "USD"
-          },
           "netTotalSalesSourceAmountOrZero": {
             "amount": 1250,
             "currency": "USD"
@@ -12457,6 +12421,10 @@
             "currency": "USD"
           },
           "totalPlatformFeeSourceAmount": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "totalPaymentProcessingFeeSourceAmount": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -12471,7 +12439,39 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "amount": 1250,
             "currency": "USD"
-          }
+          },
+          "beneficiaryList": [
+            {
+              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+              "accountName": "The Siam Residences, Bangkok",
+              "accountEmail": "reservations@thesiamresidences.com",
+              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+              "amountDue": {
+                "percent": 0.05
+              },
+              "sourceCurrency": "THB",
+              "displayCurrency": "USD",
+              "internalCurrency": "USD",
+              "sourceAmount": 450,
+              "displayAmount": 450,
+              "internalAmount": 450,
+              "sourceAmountRefundModifier": 45,
+              "displayAmountRefundModifier": 45,
+              "internalAmountRefundModifier": 45,
+              "pendingRefunds": [
+                {
+                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45
+                }
+              ],
+              "netSourceAmount": 450,
+              "netDisplayAmount": 450,
+              "netInternalAmount": 450,
+              "reconciled": false
+            }
+          ]
         },
         "properties": {
           "id": {
@@ -12887,6 +12887,28 @@
               "default": ""
             }
           },
+          "cancelled": {
+            "type": "boolean"
+          },
+          "rateSource": {
+            "type": "string"
+          },
+          "cancelledOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guestUser": {
+            "$ref": "#/components/schemas/GuestUser"
+          },
+          "cancelReason": {
+            "type": "string"
+          },
+          "ancillaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary"
+            }
+          },
           "meetingRooms": {
             "type": "array",
             "items": {
@@ -12923,38 +12945,50 @@
               "$ref": "#/components/schemas/BookingAncillary"
             }
           },
+          "roomTypeAncillaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary"
+            }
+          },
           "addOns": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BookingAncillary"
             }
           },
-          "rateSource": {
+          "cancellationType": {
+            "type": "string",
+            "description": "Reason category for a booking cancellation",
+            "enum": [
+              "DUPLICATE",
+              "CANCELLATION",
+              "NO_SHOW",
+              "CC_INVALID",
+              "CC_INSUFFICIENT",
+              "DISCRETIONARY"
+            ],
+            "default": null
+          },
+          "cancellable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
+          },
+          "displayCurrency": {
             "type": "string"
-          },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary"
-            }
-          },
-          "agentPayment": {
-            "type": "boolean"
-          },
-          "guestUser": {
-            "$ref": "#/components/schemas/GuestUser"
-          },
-          "ancillaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary"
-            }
-          },
-          "agentSelfManaged": {
-            "type": "boolean"
           },
           "roomImageUrl": {
             "type": "string"
+          },
+          "netDisplayAmount": {
+            "type": "number"
+          },
+          "netTotalSalesSourceAmountOrZero": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "netSourceAmountOrZero": {
+            "type": "number"
           },
           "hasRefunds": {
             "type": "boolean"
@@ -12970,55 +13004,6 @@
             ],
             "default": null
           },
-          "cancelledOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cancellable": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
-          },
-          "displayCurrency": {
-            "type": "string"
-          },
-          "cancelReason": {
-            "type": "string"
-          },
-          "cancellationType": {
-            "type": "string",
-            "description": "Reason category for a booking cancellation",
-            "enum": [
-              "DUPLICATE",
-              "CANCELLATION",
-              "NO_SHOW",
-              "CC_INVALID",
-              "CC_INSUFFICIENT",
-              "DISCRETIONARY"
-            ],
-            "default": null
-          },
-          "paymentTransactionIdentifier": {
-            "type": "string"
-          },
-          "roomTypeAncillaries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary"
-            }
-          },
-          "totalPaymentProcessingFeeSourceAmount": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netDisplayAmount": {
-            "type": "number"
-          },
-          "netTotalSalesSourceAmountOrZero": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netSourceAmountOrZero": {
-            "type": "number"
-          },
           "bookingContractIdentifier": {
             "type": "string"
           },
@@ -13031,6 +13016,9 @@
           "totalPlatformFeeSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
+          "totalPaymentProcessingFeeSourceAmount": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
           "commissionableSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
@@ -13040,8 +13028,20 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "cancelled": {
+          "agentPayment": {
             "type": "boolean"
+          },
+          "agentSelfManaged": {
+            "type": "boolean"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary"
+            }
+          },
+          "paymentTransactionIdentifier": {
+            "type": "string"
           }
         }
       },
@@ -13486,8 +13486,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -13497,8 +13497,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -14133,8 +14133,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -14144,8 +14144,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -14285,8 +14285,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   }
                 ],
                 "petInfo": [
@@ -14314,6 +14314,18 @@
           },
           "startDate": "2025-12-24",
           "endDate": "2025-12-27",
+          "sourceTotal": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "internalTotal": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "userSpecifiedCurrencyTotal": {
+            "amount": 1250,
+            "currency": "USD"
+          },
           "beneficiaryList": [
             {
               "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -14345,19 +14357,7 @@
               "netInternalAmount": 450,
               "reconciled": false
             }
-          ],
-          "sourceTotal": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "internalTotal": {
-            "amount": 1250,
-            "currency": "USD"
-          },
-          "userSpecifiedCurrencyTotal": {
-            "amount": 1250,
-            "currency": "USD"
-          }
+          ]
         },
         "properties": {
           "room": {
@@ -14475,22 +14475,16 @@
             "description": "Check-out date",
             "example": "2025-12-27"
           },
-          "roomNights": {
+          "guests": {
             "type": "integer",
-            "format": "int64"
+            "format": "int32"
           },
           "rateSource": {
             "type": "string"
           },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary"
-            }
-          },
-          "guests": {
+          "roomNights": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "sourceTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
@@ -14500,6 +14494,12 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary"
+            }
           }
         },
         "required": [
@@ -14969,14 +14969,14 @@
           "financialBreakdown": {
             "$ref": "#/components/schemas/FinancialBreakdown"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "beneficiaryList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Beneficiary"
             }
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         }
       },
@@ -15367,8 +15367,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -15404,18 +15404,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -16908,15 +16908,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -17240,8 +17240,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -17251,8 +17251,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -17966,8 +17966,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 }
               ],
               "petInfo": [
@@ -18254,6 +18254,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -18271,9 +18274,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -18463,8 +18463,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -18474,8 +18474,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -19110,8 +19110,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -19121,8 +19121,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -19262,8 +19262,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         }
                       ],
                       "petInfo": [
@@ -19291,6 +19291,18 @@
                 },
                 "startDate": "2025-12-24",
                 "endDate": "2025-12-27",
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
                 "beneficiaryList": [
                   {
                     "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
@@ -19322,19 +19334,7 @@
                     "netInternalAmount": 450,
                     "reconciled": false
                   }
-                ],
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
+                ]
               },
               "booker": {
                 "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
@@ -19756,6 +19756,208 @@
                   "currency": "USD"
                 }
               ],
+              "guestUser": {
+                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "reservations@thesiamresidences.com",
+                "telephone": "+1 212 555 1212",
+                "profile": {
+                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                  "createdDate": "2026-01-14T09:30:00",
+                  "lastUpdate": "2026-02-03T16:45:12",
+                  "version": 3,
+                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                  "share": true,
+                  "user": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "alexandra@beaumont.com",
+                    "phone": "+66212658866",
+                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "personal": {
+                    "gender": "FEMALE",
+                    "birthDate": "1985-06-15",
+                    "maritalStatus": "MARRIED",
+                    "childQuantity": 2,
+                    "citizenship": "Thailand",
+                    "address1": "123 Petchburi Road",
+                    "address2": "Ratchathewi District",
+                    "city": "Bangkok",
+                    "state": "Bangkok",
+                    "postalCode": "10400",
+                    "country": "TH",
+                    "preferredCurrency": "USD",
+                    "language": "en",
+                    "contactPerson": [
+                      {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      }
+                    ],
+                    "petInfo": [
+                      {
+                        "name": "Luna",
+                        "type": "Golden Retriever"
+                      }
+                    ]
+                  },
+                  "preferences": {
+                    "propertyLocationPref": "Beachfront",
+                    "propertyTypePref": "Luxury Resort",
+                    "hotelChainPref": "Mandarin Oriental",
+                    "physChalFeaturePref": "Wheelchair accessible rooms",
+                    "smokingAllowed": false,
+                    "roomLocationPref": "High floor with city view",
+                    "bedTypePref": "King bed",
+                    "foodSrvcPref": "In-room dining",
+                    "guestType": "Business traveler",
+                    "mealPref": "Continental breakfast",
+                    "cuisinePref": "Thai"
+                  }
+                },
+                "fullName": "Alexandra Beaumont"
+              },
+              "ancillaryList": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
               "meetingRooms": [
                 {
                   "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -19826,8 +20028,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -19837,8 +20039,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -19958,8 +20160,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -19969,8 +20171,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -20090,8 +20292,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -20101,8 +20303,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -20222,8 +20424,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -20233,8 +20435,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -20354,8 +20556,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -20365,8 +20567,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -20486,8 +20688,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -20497,8 +20699,140 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "roomTypeAncillaries": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -20618,8 +20952,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -20629,242 +20963,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "beneficiaryList": [
-                {
-                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                  "accountName": "The Siam Residences, Bangkok",
-                  "accountEmail": "reservations@thesiamresidences.com",
-                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                  "amountDue": {
-                    "percent": 0.05
-                  },
-                  "sourceCurrency": "THB",
-                  "displayCurrency": "USD",
-                  "internalCurrency": "USD",
-                  "sourceAmount": 450,
-                  "displayAmount": 450,
-                  "internalAmount": 450,
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45,
-                  "pendingRefunds": [
-                    {
-                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45
-                    }
-                  ],
-                  "netSourceAmount": 450,
-                  "netDisplayAmount": 450,
-                  "netInternalAmount": 450,
-                  "reconciled": false
-                }
-              ],
-              "guestUser": {
-                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "reservations@thesiamresidences.com",
-                "telephone": "+1 212 555 1212",
-                "profile": {
-                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                  "createdDate": "2026-01-14T09:30:00",
-                  "lastUpdate": "2026-02-03T16:45:12",
-                  "version": 3,
-                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                  "share": true,
-                  "user": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "alexandra@beaumont.com",
-                    "phone": "+66212658866",
-                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "personal": {
-                    "gender": "FEMALE",
-                    "birthDate": "1985-06-15",
-                    "maritalStatus": "MARRIED",
-                    "childQuantity": 2,
-                    "citizenship": "Thailand",
-                    "address1": "123 Petchburi Road",
-                    "address2": "Ratchathewi District",
-                    "city": "Bangkok",
-                    "state": "Bangkok",
-                    "postalCode": "10400",
-                    "country": "TH",
-                    "preferredCurrency": "USD",
-                    "language": "en",
-                    "contactPerson": [
-                      {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      }
-                    ],
-                    "petInfo": [
-                      {
-                        "name": "Luna",
-                        "type": "Golden Retriever"
-                      }
-                    ]
-                  },
-                  "preferences": {
-                    "propertyLocationPref": "Beachfront",
-                    "propertyTypePref": "Luxury Resort",
-                    "hotelChainPref": "Mandarin Oriental",
-                    "physChalFeaturePref": "Wheelchair accessible rooms",
-                    "smokingAllowed": false,
-                    "roomLocationPref": "High floor with city view",
-                    "bedTypePref": "King bed",
-                    "foodSrvcPref": "In-room dining",
-                    "guestType": "Business traveler",
-                    "mealPref": "Continental breakfast",
-                    "cuisinePref": "Thai"
-                  }
-                },
-                "fullName": "Alexandra Beaumont"
-              },
-              "ancillaryList": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -20915,142 +21015,6 @@
                 }
               ],
               "cancellable": false,
-              "roomTypeAncillaries": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "totalPaymentProcessingFeeSourceAmount": {
-                "amount": 1250,
-                "currency": "USD"
-              },
               "netTotalSalesSourceAmountOrZero": {
                 "amount": 1250,
                 "currency": "USD"
@@ -21060,6 +21024,10 @@
                 "currency": "USD"
               },
               "totalPlatformFeeSourceAmount": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "totalPaymentProcessingFeeSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -21074,7 +21042,39 @@
               "totalSupplierAgencyFeesSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
-              }
+              },
+              "beneficiaryList": [
+                {
+                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                  "accountName": "The Siam Residences, Bangkok",
+                  "accountEmail": "reservations@thesiamresidences.com",
+                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                  "amountDue": {
+                    "percent": 0.05
+                  },
+                  "sourceCurrency": "THB",
+                  "displayCurrency": "USD",
+                  "internalCurrency": "USD",
+                  "sourceAmount": 450,
+                  "displayAmount": 450,
+                  "internalAmount": 450,
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45,
+                  "pendingRefunds": [
+                    {
+                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45
+                    }
+                  ],
+                  "netSourceAmount": 450,
+                  "netDisplayAmount": 450,
+                  "netInternalAmount": 450,
+                  "reconciled": false
+                }
+              ]
             }
           ],
           "number": 0,
@@ -21361,8 +21361,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -21809,8 +21809,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -23264,8 +23264,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -23311,18 +23311,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -24760,7 +24760,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "booking.read": "View your bookings.",
               "booking.write": "Create and update your bookings.",

--- a/schemas/reference.json
+++ b/schemas/reference.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Social network platform identifiers supported by the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/social-network"
+        "url": "https://api.wink.travel/scalar#reference/tag/social-network"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Property lookup by name.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/property"
+        "url": "https://api.wink.travel/scalar#reference/tag/property"
       }
     },
     {
@@ -46,7 +46,7 @@
       "description": "Available channel managers on Wink.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/rate-provider"
+        "url": "https://api.wink.travel/scalar#reference/tag/rate-provider"
       }
     },
     {
@@ -54,7 +54,7 @@
       "description": "Countries supported by the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/country"
+        "url": "https://api.wink.travel/scalar#reference/tag/country"
       }
     },
     {
@@ -62,7 +62,7 @@
       "description": "Supported currencies and foreign exchange rates.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/currency"
+        "url": "https://api.wink.travel/scalar#reference/tag/currency"
       }
     },
     {
@@ -70,7 +70,7 @@
       "description": "Languages supported by the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/language"
+        "url": "https://api.wink.travel/scalar#reference/tag/language"
       }
     },
     {
@@ -78,7 +78,7 @@
       "description": "Traveler lifestyle categories supported by the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/lifestyle"
+        "url": "https://api.wink.travel/scalar#reference/tag/lifestyle"
       }
     },
     {
@@ -86,7 +86,7 @@
       "description": "Timezones supported by the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/timezone"
+        "url": "https://api.wink.travel/scalar#reference/tag/timezone"
       }
     },
     {
@@ -94,7 +94,7 @@
       "description": "Resolve the caller's approximate location from their IP address.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/geo-location"
+        "url": "https://api.wink.travel/scalar#reference/tag/geo-location"
       }
     },
     {
@@ -102,7 +102,7 @@
       "description": "Retrieve supported geo-names based on the [https://geonames.org](https://geonames.org) dataset.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/geo-data"
+        "url": "https://api.wink.travel/scalar#reference/tag/geo-data"
       }
     },
     {
@@ -110,7 +110,7 @@
       "description": "Online Travel Agency codes recognized by the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/ota"
+        "url": "https://api.wink.travel/scalar#reference/tag/ota"
       }
     },
     {
@@ -118,7 +118,7 @@
       "description": "Loyalty perks and benefits recognized across the platform.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#reference/tag/perk"
+        "url": "https://api.wink.travel/scalar#reference/tag/perk"
       }
     }
   ],
@@ -4919,15 +4919,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -5636,7 +5636,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "account.read": "View your account settings.",
               "account.write": "Create and update your account settings.",

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Manage configuration templates you can assign to our Web Components such as look-and-feel, integrations with 3rd parties and more.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/customization"
+        "url": "https://api.wink.travel/scalar#settings/tag/customization"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Manage Revolut payout destinations for a managing entity.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/revolut"
+        "url": "https://api.wink.travel/scalar#settings/tag/revolut"
       }
     },
     {
@@ -50,7 +50,7 @@
       "description": "Manage bank accounts for payout on a managing entity.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/bank-account"
+        "url": "https://api.wink.travel/scalar#settings/tag/bank-account"
       }
     },
     {
@@ -58,7 +58,7 @@
       "description": "Use the Webhook API to create webhooks to interface with the TripPay API.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/webhook"
+        "url": "https://api.wink.travel/scalar#settings/tag/webhook"
       }
     },
     {
@@ -66,7 +66,7 @@
       "description": "Manage the brand imagery for a managing entity — logo and profile picture.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/assets"
+        "url": "https://api.wink.travel/scalar#settings/tag/assets"
       }
     },
     {
@@ -74,7 +74,7 @@
       "description": "Designate another platform entity as the managing agency for your account to entitle it to a commission.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/agency"
+        "url": "https://api.wink.travel/scalar#settings/tag/agency"
       }
     },
     {
@@ -82,7 +82,7 @@
       "description": "Invite and manage users who co-manage your account.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/manager"
+        "url": "https://api.wink.travel/scalar#settings/tag/manager"
       }
     },
     {
@@ -90,7 +90,7 @@
       "description": "Managing entities are the parent entities of property, affiliate and payment accounts.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/managing-entity"
+        "url": "https://api.wink.travel/scalar#settings/tag/managing-entity"
       }
     },
     {
@@ -98,7 +98,7 @@
       "description": "The Notifications API is a way for us to stay in touch with your user, property or affiliate account.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#settings/tag/notification"
+        "url": "https://api.wink.travel/scalar#settings/tag/notification"
       }
     }
   ],
@@ -12297,8 +12297,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "revolutCounterpartyId": "rpcid_bxn8f2eKgWqxP9T7mL"
         },
@@ -12438,15 +12438,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -13016,6 +13016,9 @@
             "default": "",
             "description": "Travel agent details."
           },
+          "owner": {
+            "$ref": "#/components/schemas/ManagingEntityManager_ManagingEntity"
+          },
           "accounts": {
             "type": "array",
             "deprecated": true,
@@ -13025,9 +13028,6 @@
           },
           "verified": {
             "type": "boolean"
-          },
-          "owner": {
-            "$ref": "#/components/schemas/ManagingEntityManager_ManagingEntity"
           }
         },
         "required": [
@@ -13488,8 +13488,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -13535,18 +13535,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -15260,8 +15260,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           }
         },
         "properties": {
@@ -15346,8 +15346,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "travelAgent": {
             "selfAcquires": false,
@@ -15873,8 +15873,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "revolutCounterpartyId": "rpcid_bxn8f2eKgWqxP9T7mL"
         },
@@ -16014,15 +16014,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -16554,6 +16554,9 @@
             "default": "",
             "description": "Travel agent details."
           },
+          "owner": {
+            "$ref": "#/components/schemas/ManagingEntityManager_Authenticated_Entity"
+          },
           "accounts": {
             "type": "array",
             "deprecated": true,
@@ -16563,9 +16566,6 @@
           },
           "verified": {
             "type": "boolean"
-          },
-          "owner": {
-            "$ref": "#/components/schemas/ManagingEntityManager_Authenticated_Entity"
           }
         },
         "required": [
@@ -17026,8 +17026,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -17073,18 +17073,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -18011,8 +18011,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "revolutCounterpartyId": "rpcid_bxn8f2eKgWqxP9T7mL"
         },
@@ -18152,15 +18152,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -18730,6 +18730,9 @@
             "default": "",
             "description": "Travel agent details."
           },
+          "owner": {
+            "$ref": "#/components/schemas/ManagingEntityManager_Supplier"
+          },
           "accounts": {
             "type": "array",
             "deprecated": true,
@@ -18739,9 +18742,6 @@
           },
           "verified": {
             "type": "boolean"
-          },
-          "owner": {
-            "$ref": "#/components/schemas/ManagingEntityManager_Supplier"
           }
         },
         "required": [
@@ -19202,8 +19202,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -19249,18 +19249,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -19657,7 +19657,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "account.read": "View your account settings.",
               "account.write": "Create and update your account settings.",

--- a/schemas/social.json
+++ b/schemas/social.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Connect and disconnect social platform accounts. (Subscription required)",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#social/tag/connections"
+        "url": "https://api.wink.travel/scalar#social/tag/connections"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Schedule and manage social media posts. (Subscription required)",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#social/tag/posts"
+        "url": "https://api.wink.travel/scalar#social/tag/posts"
       }
     },
     {
@@ -46,7 +46,7 @@
       "description": "Configure managed social settings for the account. (Subscription required)",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#social/tag/settings"
+        "url": "https://api.wink.travel/scalar#social/tag/settings"
       }
     }
   ],
@@ -2921,15 +2921,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -4152,7 +4152,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "marketing.read": "View your marketing & promotions.",
               "marketing.write": "Create and update your marketing & promotions.",

--- a/schemas/studio.json
+++ b/schemas/studio.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Consists of search filters that produce a list of supplier / inventory when queried.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/saved-search"
+        "url": "https://api.wink.travel/scalar#studio/tag/saved-search"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Before you can sell travel inventory, you need to find it. Discover travel inventory that fits your niche and your audience.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/browse-supplier"
+        "url": "https://api.wink.travel/scalar#studio/tag/browse-supplier"
       }
     },
     {
@@ -50,7 +50,7 @@
       "description": "Browse and discover properties available for partnership. Affiliates can search, filter, and retrieve supplier details for integration with their distribution networks.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/available-suppliers"
+        "url": "https://api.wink.travel/scalar#studio/tag/available-suppliers"
       }
     },
     {
@@ -58,7 +58,7 @@
       "description": "Before you can sell travel inventory, you need to find it. Discover travel inventory that fits your niche and your audience.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/catalog"
+        "url": "https://api.wink.travel/scalar#studio/tag/catalog"
       }
     },
     {
@@ -66,7 +66,7 @@
       "description": "Pageable grids based on searching for blocking by a specific score type and a region.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/ranked-grid"
+        "url": "https://api.wink.travel/scalar#studio/tag/ranked-grid"
       }
     },
     {
@@ -74,7 +74,7 @@
       "description": "Account relationships are initiated by either affiliate or company and allows for companys to give sales channel specific pricing to affiliates on an individual basis.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/connect-with-supplier"
+        "url": "https://api.wink.travel/scalar#studio/tag/connect-with-supplier"
       }
     },
     {
@@ -82,7 +82,7 @@
       "description": "Before you can sell travel inventory, you need to find it. Discover travel inventorythat fits your niche and your audience.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/browse-inventory"
+        "url": "https://api.wink.travel/scalar#studio/tag/browse-inventory"
       }
     },
     {
@@ -90,7 +90,7 @@
       "description": "Displays relationships between affiliates and suppliers.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/sales-channel"
+        "url": "https://api.wink.travel/scalar#studio/tag/sales-channel"
       }
     },
     {
@@ -98,7 +98,7 @@
       "description": "Consumable grids based on curated lists and saved searches.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/grid"
+        "url": "https://api.wink.travel/scalar#studio/tag/grid"
       }
     },
     {
@@ -106,7 +106,7 @@
       "description": "Supplier links are a direct link to supplier homepage that also includes OpenGraph friendly metadata.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/link-supplier"
+        "url": "https://api.wink.travel/scalar#studio/tag/link-supplier"
       }
     },
     {
@@ -114,7 +114,7 @@
       "description": "Consists of supplier / inventoryIDs in a specific order",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/curated-list"
+        "url": "https://api.wink.travel/scalar#studio/tag/curated-list"
       }
     },
     {
@@ -126,7 +126,7 @@
       "description": "Links are the simplest form of travel inventory and can be shared everywhere and contains OpenGraph metadata. The same links can also be used with our ad banner Web Component.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/link-inventory"
+        "url": "https://api.wink.travel/scalar#studio/tag/link-inventory"
       }
     },
     {
@@ -134,7 +134,7 @@
       "description": "Single travel inventory record a seller has configured and made available for sale.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/card"
+        "url": "https://api.wink.travel/scalar#studio/tag/card"
       }
     },
     {
@@ -142,7 +142,7 @@
       "description": "Configure and manage maps, map data and overlays that you wish to display to your users.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/map"
+        "url": "https://api.wink.travel/scalar#studio/tag/map"
       }
     },
     {
@@ -150,7 +150,7 @@
       "description": "Create and track the analytics data sets you created and find interesting.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#studio/tag/analytics"
+        "url": "https://api.wink.travel/scalar#studio/tag/analytics"
       }
     }
   ],
@@ -7353,7 +7353,7 @@
                       ],
                       "createdDate": "2026-01-14T09:30:00",
                       "lastUpdate": "2026-02-03T16:45:12",
-                      "aggregatedItemDescriptions": [
+                      "effectiveDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -7361,7 +7361,7 @@
                           "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                         }
                       ],
-                      "effectiveDescriptions": [
+                      "aggregatedItemDescriptions": [
                         {
                           "description": "This is a longer description in the specified language.",
                           "language": "en",
@@ -16266,7 +16266,7 @@
                           ],
                           "createdDate": "2026-01-14T09:30:00",
                           "lastUpdate": "2026-02-03T16:45:12",
-                          "aggregatedItemDescriptions": [
+                          "effectiveDescriptions": [
                             {
                               "description": "This is a longer description in the specified language.",
                               "language": "en",
@@ -16274,7 +16274,7 @@
                               "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                             }
                           ],
-                          "effectiveDescriptions": [
+                          "aggregatedItemDescriptions": [
                             {
                               "description": "This is a longer description in the specified language.",
                               "language": "en",
@@ -20448,15 +20448,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -26483,8 +26483,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -26520,18 +26520,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -27571,8 +27571,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -27618,18 +27618,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -28395,7 +28395,7 @@
                   ],
                   "createdDate": "2026-01-14T09:30:00",
                   "lastUpdate": "2026-02-03T16:45:12",
-                  "aggregatedItemDescriptions": [
+                  "effectiveDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -28403,7 +28403,7 @@
                       "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                     }
                   ],
-                  "effectiveDescriptions": [
+                  "aggregatedItemDescriptions": [
                     {
                       "description": "This is a longer description in the specified language.",
                       "language": "en",
@@ -28722,7 +28722,7 @@
               ],
               "createdDate": "2026-01-14T09:30:00",
               "lastUpdate": "2026-02-03T16:45:12",
-              "aggregatedItemDescriptions": [
+              "effectiveDescriptions": [
                 {
                   "description": "This is a longer description in the specified language.",
                   "language": "en",
@@ -28730,7 +28730,7 @@
                   "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
                 }
               ],
-              "effectiveDescriptions": [
+              "aggregatedItemDescriptions": [
                 {
                   "description": "This is a longer description in the specified language.",
                   "language": "en",
@@ -29043,7 +29043,7 @@
           ],
           "createdDate": "2026-01-14T09:30:00",
           "lastUpdate": "2026-02-03T16:45:12",
-          "aggregatedItemDescriptions": [
+          "effectiveDescriptions": [
             {
               "description": "This is a longer description in the specified language.",
               "language": "en",
@@ -29051,7 +29051,7 @@
               "md5ContentHash": "d41d8cd98f00b204e9800998ecf8427e"
             }
           ],
-          "effectiveDescriptions": [
+          "aggregatedItemDescriptions": [
             {
               "description": "This is a longer description in the specified language.",
               "language": "en",
@@ -29182,6 +29182,16 @@
             "example": "2026-02-03T16:45:12",
             "readOnly": true
           },
+          "isValid": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "effectiveDescriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocalizedDescription_ManagingEntity"
+            }
+          },
           "aggregatedItemDescriptions": {
             "type": "array",
             "items": {
@@ -29193,16 +29203,6 @@
           },
           "hasPercentDiscountModifier": {
             "type": "boolean"
-          },
-          "effectiveDescriptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LocalizedDescription_ManagingEntity"
-            }
-          },
-          "isValid": {
-            "type": "boolean",
-            "writeOnly": true
           }
         },
         "required": [
@@ -31515,7 +31515,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "marketing.read": "View your marketing & promotions.",
               "marketing.write": "Create and update your marketing & promotions.",

--- a/schemas/travel-agent.json
+++ b/schemas/travel-agent.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -30,7 +30,7 @@
       "description": "Travel Agent API is a collection of endpoints for agents to access and manage the bookings they facilitated.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#travel-agent/tag/booking"
+        "url": "https://api.wink.travel/scalar#travel-agent/tag/booking"
       }
     },
     {
@@ -38,7 +38,7 @@
       "description": "Generate and export your booking data as a CSV file.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#travel-agent/tag/reports"
+        "url": "https://api.wink.travel/scalar#travel-agent/tag/reports"
       }
     }
   ],
@@ -256,8 +256,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -267,8 +267,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -675,8 +675,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -686,8 +686,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -827,8 +827,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -1288,6 +1288,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -1358,8 +1560,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -1369,8 +1571,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -1490,8 +1692,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -1501,8 +1703,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -1622,8 +1824,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -1633,8 +1835,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -1754,8 +1956,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -1765,8 +1967,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -1886,8 +2088,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -1897,8 +2099,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -2018,8 +2220,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -2029,8 +2231,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -2150,8 +2484,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -2161,242 +2495,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -2447,142 +2547,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -2592,6 +2556,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -2606,7 +2574,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -2956,8 +2956,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -2967,8 +2967,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -3375,8 +3375,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -3386,8 +3386,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -3527,8 +3527,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -3988,6 +3988,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -4058,8 +4260,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4069,8 +4271,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4190,8 +4392,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4201,8 +4403,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4322,8 +4524,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4333,8 +4535,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4454,8 +4656,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4465,8 +4667,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4586,8 +4788,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4597,8 +4799,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4718,8 +4920,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4729,8 +4931,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4850,8 +5184,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4861,242 +5195,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -5147,142 +5247,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -5292,6 +5256,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -5306,7 +5274,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -5839,8 +5839,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -5850,8 +5850,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -6258,8 +6258,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -6269,8 +6269,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -6410,8 +6410,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 }
                               ],
                               "petInfo": [
@@ -6871,6 +6871,208 @@
                           "currency": "USD"
                         }
                       ],
+                      "guestUser": {
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "reservations@thesiamresidences.com",
+                        "telephone": "+1 212 555 1212",
+                        "profile": {
+                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                          "createdDate": "2026-01-14T09:30:00",
+                          "lastUpdate": "2026-02-03T16:45:12",
+                          "version": 3,
+                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                          "share": true,
+                          "user": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "alexandra@beaumont.com",
+                            "phone": "+66212658866",
+                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                            "fullName": "Alexandra Beaumont"
+                          },
+                          "personal": {
+                            "gender": "FEMALE",
+                            "birthDate": "1985-06-15",
+                            "maritalStatus": "MARRIED",
+                            "childQuantity": 2,
+                            "citizenship": "Thailand",
+                            "address1": "123 Petchburi Road",
+                            "address2": "Ratchathewi District",
+                            "city": "Bangkok",
+                            "state": "Bangkok",
+                            "postalCode": "10400",
+                            "country": "TH",
+                            "preferredCurrency": "USD",
+                            "language": "en",
+                            "contactPerson": [
+                              {
+                                "firstName": "Alexandra",
+                                "lastName": "Beaumont",
+                                "email": "johnsmith@email.com",
+                                "secondaryEmail": "johnsmith2@email.com",
+                                "phoneNumber": "+12125551212",
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                              }
+                            ],
+                            "petInfo": [
+                              {
+                                "name": "Luna",
+                                "type": "Golden Retriever"
+                              }
+                            ]
+                          },
+                          "preferences": {
+                            "propertyLocationPref": "Beachfront",
+                            "propertyTypePref": "Luxury Resort",
+                            "hotelChainPref": "Mandarin Oriental",
+                            "physChalFeaturePref": "Wheelchair accessible rooms",
+                            "smokingAllowed": false,
+                            "roomLocationPref": "High floor with city view",
+                            "bedTypePref": "King bed",
+                            "foodSrvcPref": "In-room dining",
+                            "guestType": "Business traveler",
+                            "mealPref": "Continental breakfast",
+                            "cuisinePref": "Thai"
+                          }
+                        },
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "ancillaryList": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
                       "meetingRooms": [
                         {
                           "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -6941,8 +7143,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -6952,8 +7154,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7073,8 +7275,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7084,8 +7286,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7205,8 +7407,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7216,8 +7418,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7337,8 +7539,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7348,8 +7550,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7469,8 +7671,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7480,8 +7682,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7601,8 +7803,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7612,8 +7814,140 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "roomTypeAncillaries": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7733,8 +8067,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7744,242 +8078,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ],
-                      "guestUser": {
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "reservations@thesiamresidences.com",
-                        "telephone": "+1 212 555 1212",
-                        "profile": {
-                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                          "createdDate": "2026-01-14T09:30:00",
-                          "lastUpdate": "2026-02-03T16:45:12",
-                          "version": 3,
-                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                          "share": true,
-                          "user": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "alexandra@beaumont.com",
-                            "phone": "+66212658866",
-                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "personal": {
-                            "gender": "FEMALE",
-                            "birthDate": "1985-06-15",
-                            "maritalStatus": "MARRIED",
-                            "childQuantity": 2,
-                            "citizenship": "Thailand",
-                            "address1": "123 Petchburi Road",
-                            "address2": "Ratchathewi District",
-                            "city": "Bangkok",
-                            "state": "Bangkok",
-                            "postalCode": "10400",
-                            "country": "TH",
-                            "preferredCurrency": "USD",
-                            "language": "en",
-                            "contactPerson": [
-                              {
-                                "firstName": "Alexandra",
-                                "lastName": "Beaumont",
-                                "email": "johnsmith@email.com",
-                                "secondaryEmail": "johnsmith2@email.com",
-                                "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
-                              }
-                            ],
-                            "petInfo": [
-                              {
-                                "name": "Luna",
-                                "type": "Golden Retriever"
-                              }
-                            ]
-                          },
-                          "preferences": {
-                            "propertyLocationPref": "Beachfront",
-                            "propertyTypePref": "Luxury Resort",
-                            "hotelChainPref": "Mandarin Oriental",
-                            "physChalFeaturePref": "Wheelchair accessible rooms",
-                            "smokingAllowed": false,
-                            "roomLocationPref": "High floor with city view",
-                            "bedTypePref": "King bed",
-                            "foodSrvcPref": "In-room dining",
-                            "guestType": "Business traveler",
-                            "mealPref": "Continental breakfast",
-                            "cuisinePref": "Thai"
-                          }
-                        },
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "ancillaryList": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -8030,142 +8130,6 @@
                         }
                       ],
                       "cancellable": false,
-                      "roomTypeAncillaries": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "totalPaymentProcessingFeeSourceAmount": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
                       "netTotalSalesSourceAmountOrZero": {
                         "amount": 1250,
                         "currency": "USD"
@@ -8175,6 +8139,10 @@
                         "currency": "USD"
                       },
                       "totalPlatformFeeSourceAmount": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "totalPaymentProcessingFeeSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
                       },
@@ -8189,7 +8157,39 @@
                       "totalSupplierAgencyFeesSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
-                      }
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
                     }
                   ],
                   "number": 0,
@@ -8949,8 +8949,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -8960,8 +8960,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -9368,8 +9368,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -9379,8 +9379,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -9520,8 +9520,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -9981,6 +9981,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -10051,8 +10253,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10062,8 +10264,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -10183,8 +10385,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10194,8 +10396,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -10315,8 +10517,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10326,8 +10528,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -10447,8 +10649,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10458,8 +10660,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -10579,8 +10781,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10590,8 +10792,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -10711,8 +10913,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10722,8 +10924,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -10843,8 +11177,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -10854,242 +11188,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -11140,142 +11240,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -11285,6 +11249,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -11299,7 +11267,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -12841,8 +12841,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -12852,8 +12852,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "financialBreakdown": {
             "displayPriceQuote": {
@@ -13274,18 +13274,6 @@
               "default": ""
             }
           },
-          "guests": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total guests for this stay"
-          },
-          "rooms": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total rooms for this stay"
-          },
           "hours": {
             "type": "integer",
             "format": "int64",
@@ -13298,6 +13286,18 @@
             "format": "int32",
             "default": "",
             "description": "How many total children for this stay"
+          },
+          "guests": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total guests for this stay"
+          },
+          "rooms": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total rooms for this stay"
           }
         },
         "required": [
@@ -13455,8 +13455,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -13466,8 +13466,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -13874,8 +13874,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -13885,8 +13885,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "financialBreakdown": {
                   "displayPriceQuote": {
@@ -14026,8 +14026,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     }
                   ],
                   "petInfo": [
@@ -14487,6 +14487,208 @@
               "currency": "USD"
             }
           ],
+          "guestUser": {
+            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+            "firstName": "Alexandra",
+            "lastName": "Beaumont",
+            "email": "reservations@thesiamresidences.com",
+            "telephone": "+1 212 555 1212",
+            "profile": {
+              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+              "createdDate": "2026-01-14T09:30:00",
+              "lastUpdate": "2026-02-03T16:45:12",
+              "version": 3,
+              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+              "share": true,
+              "user": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "alexandra@beaumont.com",
+                "phone": "+66212658866",
+                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                "fullName": "Alexandra Beaumont"
+              },
+              "personal": {
+                "gender": "FEMALE",
+                "birthDate": "1985-06-15",
+                "maritalStatus": "MARRIED",
+                "childQuantity": 2,
+                "citizenship": "Thailand",
+                "address1": "123 Petchburi Road",
+                "address2": "Ratchathewi District",
+                "city": "Bangkok",
+                "state": "Bangkok",
+                "postalCode": "10400",
+                "country": "TH",
+                "preferredCurrency": "USD",
+                "language": "en",
+                "contactPerson": [
+                  {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  }
+                ],
+                "petInfo": [
+                  {
+                    "name": "Luna",
+                    "type": "Golden Retriever"
+                  }
+                ]
+              },
+              "preferences": {
+                "propertyLocationPref": "Beachfront",
+                "propertyTypePref": "Luxury Resort",
+                "hotelChainPref": "Mandarin Oriental",
+                "physChalFeaturePref": "Wheelchair accessible rooms",
+                "smokingAllowed": false,
+                "roomLocationPref": "High floor with city view",
+                "bedTypePref": "King bed",
+                "foodSrvcPref": "In-room dining",
+                "guestType": "Business traveler",
+                "mealPref": "Continental breakfast",
+                "cuisinePref": "Thai"
+              }
+            },
+            "fullName": "Alexandra Beaumont"
+          },
+          "ancillaryList": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
           "meetingRooms": [
             {
               "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -14557,8 +14759,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -14568,8 +14770,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -14689,8 +14891,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -14700,8 +14902,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -14821,8 +15023,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -14832,8 +15034,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -14953,8 +15155,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -14964,8 +15166,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -15085,8 +15287,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -15096,8 +15298,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -15217,8 +15419,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -15228,8 +15430,140 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
+          "roomTypeAncillaries": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -15349,8 +15683,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -15360,242 +15694,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "beneficiaryList": [
-            {
-              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-              "accountName": "The Siam Residences, Bangkok",
-              "accountEmail": "reservations@thesiamresidences.com",
-              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-              "amountDue": {
-                "percent": 0.05
-              },
-              "sourceCurrency": "THB",
-              "displayCurrency": "USD",
-              "internalCurrency": "USD",
-              "sourceAmount": 450,
-              "displayAmount": 450,
-              "internalAmount": 450,
-              "sourceAmountRefundModifier": 45,
-              "displayAmountRefundModifier": 45,
-              "internalAmountRefundModifier": 45,
-              "pendingRefunds": [
-                {
-                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45
-                }
-              ],
-              "netSourceAmount": 450,
-              "netDisplayAmount": 450,
-              "netInternalAmount": 450,
-              "reconciled": false
-            }
-          ],
-          "guestUser": {
-            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-            "firstName": "Alexandra",
-            "lastName": "Beaumont",
-            "email": "reservations@thesiamresidences.com",
-            "telephone": "+1 212 555 1212",
-            "profile": {
-              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-              "createdDate": "2026-01-14T09:30:00",
-              "lastUpdate": "2026-02-03T16:45:12",
-              "version": 3,
-              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-              "share": true,
-              "user": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "alexandra@beaumont.com",
-                "phone": "+66212658866",
-                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                "fullName": "Alexandra Beaumont"
-              },
-              "personal": {
-                "gender": "FEMALE",
-                "birthDate": "1985-06-15",
-                "maritalStatus": "MARRIED",
-                "childQuantity": 2,
-                "citizenship": "Thailand",
-                "address1": "123 Petchburi Road",
-                "address2": "Ratchathewi District",
-                "city": "Bangkok",
-                "state": "Bangkok",
-                "postalCode": "10400",
-                "country": "TH",
-                "preferredCurrency": "USD",
-                "language": "en",
-                "contactPerson": [
-                  {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  }
-                ],
-                "petInfo": [
-                  {
-                    "name": "Luna",
-                    "type": "Golden Retriever"
-                  }
-                ]
-              },
-              "preferences": {
-                "propertyLocationPref": "Beachfront",
-                "propertyTypePref": "Luxury Resort",
-                "hotelChainPref": "Mandarin Oriental",
-                "physChalFeaturePref": "Wheelchair accessible rooms",
-                "smokingAllowed": false,
-                "roomLocationPref": "High floor with city view",
-                "bedTypePref": "King bed",
-                "foodSrvcPref": "In-room dining",
-                "guestType": "Business traveler",
-                "mealPref": "Continental breakfast",
-                "cuisinePref": "Thai"
-              }
-            },
-            "fullName": "Alexandra Beaumont"
-          },
-          "ancillaryList": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -15646,142 +15746,6 @@
             }
           ],
           "cancellable": false,
-          "roomTypeAncillaries": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "totalPaymentProcessingFeeSourceAmount": {
-            "amount": 1250,
-            "currency": "USD"
-          },
           "netTotalSalesSourceAmountOrZero": {
             "amount": 1250,
             "currency": "USD"
@@ -15791,6 +15755,10 @@
             "currency": "USD"
           },
           "totalPlatformFeeSourceAmount": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "totalPaymentProcessingFeeSourceAmount": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -15805,7 +15773,39 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "amount": 1250,
             "currency": "USD"
-          }
+          },
+          "beneficiaryList": [
+            {
+              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+              "accountName": "The Siam Residences, Bangkok",
+              "accountEmail": "reservations@thesiamresidences.com",
+              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+              "amountDue": {
+                "percent": 0.05
+              },
+              "sourceCurrency": "THB",
+              "displayCurrency": "USD",
+              "internalCurrency": "USD",
+              "sourceAmount": 450,
+              "displayAmount": 450,
+              "internalAmount": 450,
+              "sourceAmountRefundModifier": 45,
+              "displayAmountRefundModifier": 45,
+              "internalAmountRefundModifier": 45,
+              "pendingRefunds": [
+                {
+                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45
+                }
+              ],
+              "netSourceAmount": 450,
+              "netDisplayAmount": 450,
+              "netInternalAmount": 450,
+              "reconciled": false
+            }
+          ]
         },
         "properties": {
           "id": {
@@ -16215,6 +16215,28 @@
               "default": ""
             }
           },
+          "cancelled": {
+            "type": "boolean"
+          },
+          "rateSource": {
+            "type": "string"
+          },
+          "cancelledOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guestUser": {
+            "$ref": "#/components/schemas/GuestUser_Agent"
+          },
+          "cancelReason": {
+            "type": "string"
+          },
+          "ancillaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_Agent"
+            }
+          },
           "meetingRooms": {
             "type": "array",
             "items": {
@@ -16251,38 +16273,50 @@
               "$ref": "#/components/schemas/BookingAncillary_Agent"
             }
           },
+          "roomTypeAncillaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_Agent"
+            }
+          },
           "addOns": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BookingAncillary_Agent"
             }
           },
-          "rateSource": {
+          "cancellationType": {
+            "type": "string",
+            "description": "Reason category for a booking cancellation",
+            "enum": [
+              "DUPLICATE",
+              "CANCELLATION",
+              "NO_SHOW",
+              "CC_INVALID",
+              "CC_INSUFFICIENT",
+              "DISCRETIONARY"
+            ],
+            "default": null
+          },
+          "cancellable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
+          },
+          "displayCurrency": {
             "type": "string"
-          },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary_Agent"
-            }
-          },
-          "agentPayment": {
-            "type": "boolean"
-          },
-          "guestUser": {
-            "$ref": "#/components/schemas/GuestUser_Agent"
-          },
-          "ancillaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_Agent"
-            }
-          },
-          "agentSelfManaged": {
-            "type": "boolean"
           },
           "roomImageUrl": {
             "type": "string"
+          },
+          "netDisplayAmount": {
+            "type": "number"
+          },
+          "netTotalSalesSourceAmountOrZero": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "netSourceAmountOrZero": {
+            "type": "number"
           },
           "hasRefunds": {
             "type": "boolean"
@@ -16298,55 +16332,6 @@
             ],
             "default": null
           },
-          "cancelledOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cancellable": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
-          },
-          "displayCurrency": {
-            "type": "string"
-          },
-          "cancelReason": {
-            "type": "string"
-          },
-          "cancellationType": {
-            "type": "string",
-            "description": "Reason category for a booking cancellation",
-            "enum": [
-              "DUPLICATE",
-              "CANCELLATION",
-              "NO_SHOW",
-              "CC_INVALID",
-              "CC_INSUFFICIENT",
-              "DISCRETIONARY"
-            ],
-            "default": null
-          },
-          "paymentTransactionIdentifier": {
-            "type": "string"
-          },
-          "roomTypeAncillaries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_Agent"
-            }
-          },
-          "totalPaymentProcessingFeeSourceAmount": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netDisplayAmount": {
-            "type": "number"
-          },
-          "netTotalSalesSourceAmountOrZero": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netSourceAmountOrZero": {
-            "type": "number"
-          },
           "bookingContractIdentifier": {
             "type": "string"
           },
@@ -16359,6 +16344,9 @@
           "totalPlatformFeeSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
+          "totalPaymentProcessingFeeSourceAmount": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
           "commissionableSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
@@ -16368,8 +16356,20 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "cancelled": {
+          "agentPayment": {
             "type": "boolean"
+          },
+          "agentSelfManaged": {
+            "type": "boolean"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary_Agent"
+            }
+          },
+          "paymentTransactionIdentifier": {
+            "type": "string"
           }
         }
       },
@@ -16814,8 +16814,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -16825,8 +16825,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -17233,8 +17233,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -17244,8 +17244,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -17385,8 +17385,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   }
                 ],
                 "petInfo": [
@@ -17543,16 +17543,16 @@
             "description": "Check-out date",
             "example": "2025-12-27"
           },
-          "roomNights": {
+          "guests": {
             "type": "integer",
-            "format": "int64"
+            "format": "int32"
           },
           "rateSource": {
             "type": "string"
           },
-          "guests": {
+          "roomNights": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "sourceTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
@@ -18258,8 +18258,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -18295,18 +18295,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -19710,15 +19710,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -19948,8 +19948,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -19959,8 +19959,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -20588,8 +20588,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 }
               ],
               "petInfo": [
@@ -20876,6 +20876,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -20893,9 +20896,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -21085,8 +21085,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -21096,8 +21096,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -21504,8 +21504,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -21515,8 +21515,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -21656,8 +21656,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         }
                       ],
                       "petInfo": [
@@ -22117,6 +22117,208 @@
                   "currency": "USD"
                 }
               ],
+              "guestUser": {
+                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "reservations@thesiamresidences.com",
+                "telephone": "+1 212 555 1212",
+                "profile": {
+                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                  "createdDate": "2026-01-14T09:30:00",
+                  "lastUpdate": "2026-02-03T16:45:12",
+                  "version": 3,
+                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                  "share": true,
+                  "user": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "alexandra@beaumont.com",
+                    "phone": "+66212658866",
+                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "personal": {
+                    "gender": "FEMALE",
+                    "birthDate": "1985-06-15",
+                    "maritalStatus": "MARRIED",
+                    "childQuantity": 2,
+                    "citizenship": "Thailand",
+                    "address1": "123 Petchburi Road",
+                    "address2": "Ratchathewi District",
+                    "city": "Bangkok",
+                    "state": "Bangkok",
+                    "postalCode": "10400",
+                    "country": "TH",
+                    "preferredCurrency": "USD",
+                    "language": "en",
+                    "contactPerson": [
+                      {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      }
+                    ],
+                    "petInfo": [
+                      {
+                        "name": "Luna",
+                        "type": "Golden Retriever"
+                      }
+                    ]
+                  },
+                  "preferences": {
+                    "propertyLocationPref": "Beachfront",
+                    "propertyTypePref": "Luxury Resort",
+                    "hotelChainPref": "Mandarin Oriental",
+                    "physChalFeaturePref": "Wheelchair accessible rooms",
+                    "smokingAllowed": false,
+                    "roomLocationPref": "High floor with city view",
+                    "bedTypePref": "King bed",
+                    "foodSrvcPref": "In-room dining",
+                    "guestType": "Business traveler",
+                    "mealPref": "Continental breakfast",
+                    "cuisinePref": "Thai"
+                  }
+                },
+                "fullName": "Alexandra Beaumont"
+              },
+              "ancillaryList": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
               "meetingRooms": [
                 {
                   "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -22187,8 +22389,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22198,8 +22400,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -22319,8 +22521,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22330,8 +22532,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -22451,8 +22653,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22462,8 +22664,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -22583,8 +22785,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22594,8 +22796,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -22715,8 +22917,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22726,8 +22928,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -22847,8 +23049,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22858,8 +23060,140 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "roomTypeAncillaries": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -22979,8 +23313,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -22990,242 +23324,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "beneficiaryList": [
-                {
-                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                  "accountName": "The Siam Residences, Bangkok",
-                  "accountEmail": "reservations@thesiamresidences.com",
-                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                  "amountDue": {
-                    "percent": 0.05
-                  },
-                  "sourceCurrency": "THB",
-                  "displayCurrency": "USD",
-                  "internalCurrency": "USD",
-                  "sourceAmount": 450,
-                  "displayAmount": 450,
-                  "internalAmount": 450,
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45,
-                  "pendingRefunds": [
-                    {
-                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45
-                    }
-                  ],
-                  "netSourceAmount": 450,
-                  "netDisplayAmount": 450,
-                  "netInternalAmount": 450,
-                  "reconciled": false
-                }
-              ],
-              "guestUser": {
-                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "reservations@thesiamresidences.com",
-                "telephone": "+1 212 555 1212",
-                "profile": {
-                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                  "createdDate": "2026-01-14T09:30:00",
-                  "lastUpdate": "2026-02-03T16:45:12",
-                  "version": 3,
-                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                  "share": true,
-                  "user": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "alexandra@beaumont.com",
-                    "phone": "+66212658866",
-                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "personal": {
-                    "gender": "FEMALE",
-                    "birthDate": "1985-06-15",
-                    "maritalStatus": "MARRIED",
-                    "childQuantity": 2,
-                    "citizenship": "Thailand",
-                    "address1": "123 Petchburi Road",
-                    "address2": "Ratchathewi District",
-                    "city": "Bangkok",
-                    "state": "Bangkok",
-                    "postalCode": "10400",
-                    "country": "TH",
-                    "preferredCurrency": "USD",
-                    "language": "en",
-                    "contactPerson": [
-                      {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      }
-                    ],
-                    "petInfo": [
-                      {
-                        "name": "Luna",
-                        "type": "Golden Retriever"
-                      }
-                    ]
-                  },
-                  "preferences": {
-                    "propertyLocationPref": "Beachfront",
-                    "propertyTypePref": "Luxury Resort",
-                    "hotelChainPref": "Mandarin Oriental",
-                    "physChalFeaturePref": "Wheelchair accessible rooms",
-                    "smokingAllowed": false,
-                    "roomLocationPref": "High floor with city view",
-                    "bedTypePref": "King bed",
-                    "foodSrvcPref": "In-room dining",
-                    "guestType": "Business traveler",
-                    "mealPref": "Continental breakfast",
-                    "cuisinePref": "Thai"
-                  }
-                },
-                "fullName": "Alexandra Beaumont"
-              },
-              "ancillaryList": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -23276,142 +23376,6 @@
                 }
               ],
               "cancellable": false,
-              "roomTypeAncillaries": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "totalPaymentProcessingFeeSourceAmount": {
-                "amount": 1250,
-                "currency": "USD"
-              },
               "netTotalSalesSourceAmountOrZero": {
                 "amount": 1250,
                 "currency": "USD"
@@ -23421,6 +23385,10 @@
                 "currency": "USD"
               },
               "totalPlatformFeeSourceAmount": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "totalPaymentProcessingFeeSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -23435,7 +23403,39 @@
               "totalSupplierAgencyFeesSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
-              }
+              },
+              "beneficiaryList": [
+                {
+                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                  "accountName": "The Siam Residences, Bangkok",
+                  "accountEmail": "reservations@thesiamresidences.com",
+                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                  "amountDue": {
+                    "percent": 0.05
+                  },
+                  "sourceCurrency": "THB",
+                  "displayCurrency": "USD",
+                  "internalCurrency": "USD",
+                  "sourceAmount": 450,
+                  "displayAmount": 450,
+                  "internalAmount": 450,
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45,
+                  "pendingRefunds": [
+                    {
+                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45
+                    }
+                  ],
+                  "netSourceAmount": 450,
+                  "netDisplayAmount": 450,
+                  "netInternalAmount": 450,
+                  "reconciled": false
+                }
+              ]
             }
           ],
           "number": 0,
@@ -23674,8 +23674,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -24122,8 +24122,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -25561,8 +25561,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -25608,18 +25608,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -26894,8 +26894,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -26905,8 +26905,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -27313,8 +27313,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -27324,8 +27324,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -27465,8 +27465,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         }
                       ],
                       "petInfo": [
@@ -27926,6 +27926,208 @@
                   "currency": "USD"
                 }
               ],
+              "guestUser": {
+                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "reservations@thesiamresidences.com",
+                "telephone": "+1 212 555 1212",
+                "profile": {
+                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                  "createdDate": "2026-01-14T09:30:00",
+                  "lastUpdate": "2026-02-03T16:45:12",
+                  "version": 3,
+                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                  "share": true,
+                  "user": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "alexandra@beaumont.com",
+                    "phone": "+66212658866",
+                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "personal": {
+                    "gender": "FEMALE",
+                    "birthDate": "1985-06-15",
+                    "maritalStatus": "MARRIED",
+                    "childQuantity": 2,
+                    "citizenship": "Thailand",
+                    "address1": "123 Petchburi Road",
+                    "address2": "Ratchathewi District",
+                    "city": "Bangkok",
+                    "state": "Bangkok",
+                    "postalCode": "10400",
+                    "country": "TH",
+                    "preferredCurrency": "USD",
+                    "language": "en",
+                    "contactPerson": [
+                      {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      }
+                    ],
+                    "petInfo": [
+                      {
+                        "name": "Luna",
+                        "type": "Golden Retriever"
+                      }
+                    ]
+                  },
+                  "preferences": {
+                    "propertyLocationPref": "Beachfront",
+                    "propertyTypePref": "Luxury Resort",
+                    "hotelChainPref": "Mandarin Oriental",
+                    "physChalFeaturePref": "Wheelchair accessible rooms",
+                    "smokingAllowed": false,
+                    "roomLocationPref": "High floor with city view",
+                    "bedTypePref": "King bed",
+                    "foodSrvcPref": "In-room dining",
+                    "guestType": "Business traveler",
+                    "mealPref": "Continental breakfast",
+                    "cuisinePref": "Thai"
+                  }
+                },
+                "fullName": "Alexandra Beaumont"
+              },
+              "ancillaryList": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
               "meetingRooms": [
                 {
                   "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -27996,8 +28198,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28007,8 +28209,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -28128,8 +28330,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28139,8 +28341,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -28260,8 +28462,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28271,8 +28473,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -28392,8 +28594,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28403,8 +28605,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -28524,8 +28726,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28535,8 +28737,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -28656,8 +28858,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28667,8 +28869,140 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "roomTypeAncillaries": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -28788,8 +29122,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -28799,242 +29133,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "beneficiaryList": [
-                {
-                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                  "accountName": "The Siam Residences, Bangkok",
-                  "accountEmail": "reservations@thesiamresidences.com",
-                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                  "amountDue": {
-                    "percent": 0.05
-                  },
-                  "sourceCurrency": "THB",
-                  "displayCurrency": "USD",
-                  "internalCurrency": "USD",
-                  "sourceAmount": 450,
-                  "displayAmount": 450,
-                  "internalAmount": 450,
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45,
-                  "pendingRefunds": [
-                    {
-                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45
-                    }
-                  ],
-                  "netSourceAmount": 450,
-                  "netDisplayAmount": 450,
-                  "netInternalAmount": 450,
-                  "reconciled": false
-                }
-              ],
-              "guestUser": {
-                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "reservations@thesiamresidences.com",
-                "telephone": "+1 212 555 1212",
-                "profile": {
-                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                  "createdDate": "2026-01-14T09:30:00",
-                  "lastUpdate": "2026-02-03T16:45:12",
-                  "version": 3,
-                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                  "share": true,
-                  "user": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "alexandra@beaumont.com",
-                    "phone": "+66212658866",
-                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "personal": {
-                    "gender": "FEMALE",
-                    "birthDate": "1985-06-15",
-                    "maritalStatus": "MARRIED",
-                    "childQuantity": 2,
-                    "citizenship": "Thailand",
-                    "address1": "123 Petchburi Road",
-                    "address2": "Ratchathewi District",
-                    "city": "Bangkok",
-                    "state": "Bangkok",
-                    "postalCode": "10400",
-                    "country": "TH",
-                    "preferredCurrency": "USD",
-                    "language": "en",
-                    "contactPerson": [
-                      {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      }
-                    ],
-                    "petInfo": [
-                      {
-                        "name": "Luna",
-                        "type": "Golden Retriever"
-                      }
-                    ]
-                  },
-                  "preferences": {
-                    "propertyLocationPref": "Beachfront",
-                    "propertyTypePref": "Luxury Resort",
-                    "hotelChainPref": "Mandarin Oriental",
-                    "physChalFeaturePref": "Wheelchair accessible rooms",
-                    "smokingAllowed": false,
-                    "roomLocationPref": "High floor with city view",
-                    "bedTypePref": "King bed",
-                    "foodSrvcPref": "In-room dining",
-                    "guestType": "Business traveler",
-                    "mealPref": "Continental breakfast",
-                    "cuisinePref": "Thai"
-                  }
-                },
-                "fullName": "Alexandra Beaumont"
-              },
-              "ancillaryList": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -29085,142 +29185,6 @@
                 }
               ],
               "cancellable": false,
-              "roomTypeAncillaries": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "totalPaymentProcessingFeeSourceAmount": {
-                "amount": 1250,
-                "currency": "USD"
-              },
               "netTotalSalesSourceAmountOrZero": {
                 "amount": 1250,
                 "currency": "USD"
@@ -29230,6 +29194,10 @@
                 "currency": "USD"
               },
               "totalPlatformFeeSourceAmount": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "totalPaymentProcessingFeeSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -29244,7 +29212,39 @@
               "totalSupplierAgencyFeesSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
-              }
+              },
+              "beneficiaryList": [
+                {
+                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                  "accountName": "The Siam Residences, Bangkok",
+                  "accountEmail": "reservations@thesiamresidences.com",
+                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                  "amountDue": {
+                    "percent": 0.05
+                  },
+                  "sourceCurrency": "THB",
+                  "displayCurrency": "USD",
+                  "internalCurrency": "USD",
+                  "sourceAmount": 450,
+                  "displayAmount": 450,
+                  "internalAmount": 450,
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45,
+                  "pendingRefunds": [
+                    {
+                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45
+                    }
+                  ],
+                  "netSourceAmount": 450,
+                  "netDisplayAmount": 450,
+                  "netInternalAmount": 450,
+                  "reconciled": false
+                }
+              ]
             }
           ],
           "pointsToBeEarned": 100,
@@ -29591,7 +29591,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "booking.read": "View your bookings.",
               "booking.write": "Create and update your bookings.",

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -7,7 +7,7 @@
       "name": "Contact",
       "email": "hi@wink.travel"
     },
-    "version": "33.0.2-SNAPSHOT",
+    "version": "34.5.1",
     "x-logo": {
       "backgroundColor": "#FFFFFF",
       "altText": "wink",
@@ -20,7 +20,7 @@
   },
   "servers": [
     {
-      "url": "https://dev-api.wink.travel:8443",
+      "url": "https://api.wink.travel",
       "description": "Endpoint"
     }
   ],
@@ -34,7 +34,7 @@
       "description": "Booking endpoints allow you to create and cancel bookings as well as to retrieve all bookings.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#user/tag/booking"
+        "url": "https://api.wink.travel/scalar#user/tag/booking"
       }
     },
     {
@@ -46,7 +46,7 @@
       "description": "Manage user profile, settings and other user related functionality",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#user/tag/profile"
+        "url": "https://api.wink.travel/scalar#user/tag/profile"
       }
     },
     {
@@ -58,7 +58,7 @@
       "description": "Browse the affiliate leaderboard by region or by owner.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#user/tag/analytics"
+        "url": "https://api.wink.travel/scalar#user/tag/analytics"
       }
     },
     {
@@ -66,7 +66,7 @@
       "description": "The Notifications API is a way for us to stay in touch with your user, property or affiliate account.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#user/tag/notification"
+        "url": "https://api.wink.travel/scalar#user/tag/notification"
       }
     },
     {
@@ -74,7 +74,7 @@
       "description": "Ability to review a booking.",
       "externalDocs": {
         "description": "Try it in Scalar",
-        "url": "https://dev-api.wink.travel:8443/scalar#user/tag/review"
+        "url": "https://api.wink.travel/scalar#user/tag/review"
       }
     }
   ],
@@ -160,8 +160,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       }
                     ],
                     "petInfo": [
@@ -401,8 +401,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       }
                     ],
                     "petInfo": [
@@ -1988,8 +1988,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -1999,8 +1999,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -2407,8 +2407,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -2418,8 +2418,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -2559,8 +2559,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -3020,6 +3020,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -3090,8 +3292,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3101,8 +3303,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -3222,8 +3424,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3233,8 +3435,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -3354,8 +3556,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3365,8 +3567,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -3486,8 +3688,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3497,8 +3699,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -3618,8 +3820,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3629,8 +3831,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -3750,8 +3952,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3761,8 +3963,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -3882,8 +4216,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -3893,242 +4227,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -4179,142 +4279,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -4324,6 +4288,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -4338,7 +4306,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -4677,8 +4677,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -4688,8 +4688,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "commissionable": true,
                       "name": "Archery lesson",
@@ -5096,8 +5096,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -5107,8 +5107,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -5248,8 +5248,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             }
                           ],
                           "petInfo": [
@@ -5709,6 +5709,208 @@
                       "currency": "USD"
                     }
                   ],
+                  "guestUser": {
+                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "reservations@thesiamresidences.com",
+                    "telephone": "+1 212 555 1212",
+                    "profile": {
+                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                      "createdDate": "2026-01-14T09:30:00",
+                      "lastUpdate": "2026-02-03T16:45:12",
+                      "version": 3,
+                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "share": true,
+                      "user": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "alexandra@beaumont.com",
+                        "phone": "+66212658866",
+                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "personal": {
+                        "gender": "FEMALE",
+                        "birthDate": "1985-06-15",
+                        "maritalStatus": "MARRIED",
+                        "childQuantity": 2,
+                        "citizenship": "Thailand",
+                        "address1": "123 Petchburi Road",
+                        "address2": "Ratchathewi District",
+                        "city": "Bangkok",
+                        "state": "Bangkok",
+                        "postalCode": "10400",
+                        "country": "TH",
+                        "preferredCurrency": "USD",
+                        "language": "en",
+                        "contactPerson": [
+                          {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          }
+                        ],
+                        "petInfo": [
+                          {
+                            "name": "Luna",
+                            "type": "Golden Retriever"
+                          }
+                        ]
+                      },
+                      "preferences": {
+                        "propertyLocationPref": "Beachfront",
+                        "propertyTypePref": "Luxury Resort",
+                        "hotelChainPref": "Mandarin Oriental",
+                        "physChalFeaturePref": "Wheelchair accessible rooms",
+                        "smokingAllowed": false,
+                        "roomLocationPref": "High floor with city view",
+                        "bedTypePref": "King bed",
+                        "foodSrvcPref": "In-room dining",
+                        "guestType": "Business traveler",
+                        "mealPref": "Continental breakfast",
+                        "cuisinePref": "Thai"
+                      }
+                    },
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "ancillaryList": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "meetingRooms": [
                     {
                       "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -5779,8 +5981,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -5790,8 +5992,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -5911,8 +6113,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -5922,8 +6124,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -6043,8 +6245,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -6054,8 +6256,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -6175,8 +6377,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -6186,8 +6388,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -6307,8 +6509,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -6318,8 +6520,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -6439,8 +6641,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -6450,8 +6652,140 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                      },
+                      "financialBreakdown": {
+                        "displayPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "internalPriceQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "beneficiaryList": [
+                          {
+                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                            "accountName": "The Siam Residences, Bangkok",
+                            "accountEmail": "reservations@thesiamresidences.com",
+                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                            "amountDue": {
+                              "percent": 0.05
+                            },
+                            "sourceCurrency": "THB",
+                            "displayCurrency": "USD",
+                            "internalCurrency": "USD",
+                            "sourceAmount": 450,
+                            "displayAmount": 450,
+                            "internalAmount": 450,
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45,
+                            "pendingRefunds": [
+                              {
+                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45
+                              }
+                            ],
+                            "netSourceAmount": 450,
+                            "netDisplayAmount": 450,
+                            "netInternalAmount": 450,
+                            "reconciled": false
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "roomTypeAncillaries": [
+                    {
+                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                      "name": "Thai Massage Spa Treatment",
+                      "pricingType": "PER_USE",
+                      "type": "ADD_ON",
+                      "price": {
+                        "sourceToUserCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "sourceToInternalCurrencyQuote": {
+                          "source": "USD",
+                          "target": "THB",
+                          "exchangeRate": 33.5,
+                          "timestamp": 1705233000000
+                        },
+                        "userSpecifiedCurrencyBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "sourceBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalBaseTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyPromotionalModifier": -40,
+                        "sourcePromotionalModifier": -40,
+                        "internalPromotionalModifier": -40,
+                        "userSpecifiedCurrencyPremiumModifier": 40,
+                        "sourcePremiumModifier": 40,
+                        "internalPremiumModifier": 40,
+                        "userSpecifiedCurrencyChannelModifier": -10,
+                        "sourceChannelModifier": -10,
+                        "internalChannelModifier": -10,
+                        "quantity": 1,
+                        "sourceTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "internalTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        },
+                        "userSpecifiedCurrencyTotal": {
+                          "amount": 1250,
+                          "currency": "USD"
+                        }
+                      },
+                      "startDate": "2017-12-22T03:07:58.742+0000",
+                      "endDate": "2017-12-22T08:07:58.742+0000",
+                      "attendees": 2,
+                      "imageIdentifier": "cloudinary-image-1",
+                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                      "localizedName": "Plass 1",
+                      "localizedDescription": "place-1",
+                      "contact": {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      },
+                      "address": {
+                        "address1": "234 Near da beach",
+                        "address2": "Pebble #5001",
+                        "state": "CA",
+                        "postalCode": "90210",
+                        "county": "Alameda county",
+                        "city": "Bangkok",
+                        "countryCode": "TH",
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -6571,8 +6905,8 @@
                         "email": "johnsmith@email.com",
                         "secondaryEmail": "johnsmith2@email.com",
                         "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                       },
                       "address": {
                         "address1": "234 Near da beach",
@@ -6582,242 +6916,8 @@
                         "county": "Alameda county",
                         "city": "Bangkok",
                         "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "beneficiaryList": [
-                    {
-                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                      "accountName": "The Siam Residences, Bangkok",
-                      "accountEmail": "reservations@thesiamresidences.com",
-                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                      "amountDue": {
-                        "percent": 0.05
-                      },
-                      "sourceCurrency": "THB",
-                      "displayCurrency": "USD",
-                      "internalCurrency": "USD",
-                      "sourceAmount": 450,
-                      "displayAmount": 450,
-                      "internalAmount": 450,
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45,
-                      "pendingRefunds": [
-                        {
-                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45
-                        }
-                      ],
-                      "netSourceAmount": 450,
-                      "netDisplayAmount": 450,
-                      "netInternalAmount": 450,
-                      "reconciled": false
-                    }
-                  ],
-                  "guestUser": {
-                    "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "reservations@thesiamresidences.com",
-                    "telephone": "+1 212 555 1212",
-                    "profile": {
-                      "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                      "createdDate": "2026-01-14T09:30:00",
-                      "lastUpdate": "2026-02-03T16:45:12",
-                      "version": 3,
-                      "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "share": true,
-                      "user": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "alexandra@beaumont.com",
-                        "phone": "+66212658866",
-                        "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "personal": {
-                        "gender": "FEMALE",
-                        "birthDate": "1985-06-15",
-                        "maritalStatus": "MARRIED",
-                        "childQuantity": 2,
-                        "citizenship": "Thailand",
-                        "address1": "123 Petchburi Road",
-                        "address2": "Ratchathewi District",
-                        "city": "Bangkok",
-                        "state": "Bangkok",
-                        "postalCode": "10400",
-                        "country": "TH",
-                        "preferredCurrency": "USD",
-                        "language": "en",
-                        "contactPerson": [
-                          {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          }
-                        ],
-                        "petInfo": [
-                          {
-                            "name": "Luna",
-                            "type": "Golden Retriever"
-                          }
-                        ]
-                      },
-                      "preferences": {
-                        "propertyLocationPref": "Beachfront",
-                        "propertyTypePref": "Luxury Resort",
-                        "hotelChainPref": "Mandarin Oriental",
-                        "physChalFeaturePref": "Wheelchair accessible rooms",
-                        "smokingAllowed": false,
-                        "roomLocationPref": "High floor with city view",
-                        "bedTypePref": "King bed",
-                        "foodSrvcPref": "In-room dining",
-                        "guestType": "Business traveler",
-                        "mealPref": "Continental breakfast",
-                        "cuisinePref": "Thai"
-                      }
-                    },
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "ancillaryList": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
+                        "country": "United States",
+                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                       },
                       "financialBreakdown": {
                         "displayPriceQuote": {
@@ -6868,142 +6968,6 @@
                     }
                   ],
                   "cancellable": false,
-                  "roomTypeAncillaries": [
-                    {
-                      "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                      "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                      "name": "Thai Massage Spa Treatment",
-                      "pricingType": "PER_USE",
-                      "type": "ADD_ON",
-                      "price": {
-                        "sourceToUserCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "sourceToInternalCurrencyQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "userSpecifiedCurrencyBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "sourceBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalBaseTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyPromotionalModifier": -40,
-                        "sourcePromotionalModifier": -40,
-                        "internalPromotionalModifier": -40,
-                        "userSpecifiedCurrencyPremiumModifier": 40,
-                        "sourcePremiumModifier": 40,
-                        "internalPremiumModifier": 40,
-                        "userSpecifiedCurrencyChannelModifier": -10,
-                        "sourceChannelModifier": -10,
-                        "internalChannelModifier": -10,
-                        "quantity": 1,
-                        "sourceTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "internalTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        },
-                        "userSpecifiedCurrencyTotal": {
-                          "amount": 1250,
-                          "currency": "USD"
-                        }
-                      },
-                      "startDate": "2017-12-22T03:07:58.742+0000",
-                      "endDate": "2017-12-22T08:07:58.742+0000",
-                      "attendees": 2,
-                      "imageIdentifier": "cloudinary-image-1",
-                      "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                      "localizedName": "Plass 1",
-                      "localizedDescription": "place-1",
-                      "contact": {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "address": {
-                        "address1": "234 Near da beach",
-                        "address2": "Pebble #5001",
-                        "state": "CA",
-                        "postalCode": "90210",
-                        "county": "Alameda county",
-                        "city": "Bangkok",
-                        "countryCode": "TH",
-                        "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                        "country": "United States"
-                      },
-                      "financialBreakdown": {
-                        "displayPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "internalPriceQuote": {
-                          "source": "USD",
-                          "target": "THB",
-                          "exchangeRate": 33.5,
-                          "timestamp": 1705233000000
-                        },
-                        "beneficiaryList": [
-                          {
-                            "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                            "accountName": "The Siam Residences, Bangkok",
-                            "accountEmail": "reservations@thesiamresidences.com",
-                            "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                            "amountDue": {
-                              "percent": 0.05
-                            },
-                            "sourceCurrency": "THB",
-                            "displayCurrency": "USD",
-                            "internalCurrency": "USD",
-                            "sourceAmount": 450,
-                            "displayAmount": 450,
-                            "internalAmount": 450,
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45,
-                            "pendingRefunds": [
-                              {
-                                "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45
-                              }
-                            ],
-                            "netSourceAmount": 450,
-                            "netDisplayAmount": 450,
-                            "netInternalAmount": 450,
-                            "reconciled": false
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "totalPaymentProcessingFeeSourceAmount": {
-                    "amount": 1250,
-                    "currency": "USD"
-                  },
                   "netTotalSalesSourceAmountOrZero": {
                     "amount": 1250,
                     "currency": "USD"
@@ -7013,6 +6977,10 @@
                     "currency": "USD"
                   },
                   "totalPlatformFeeSourceAmount": {
+                    "amount": 1250,
+                    "currency": "USD"
+                  },
+                  "totalPaymentProcessingFeeSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
                   },
@@ -7027,7 +6995,39 @@
                   "totalSupplierAgencyFeesSourceAmount": {
                     "amount": 1250,
                     "currency": "USD"
-                  }
+                  },
+                  "beneficiaryList": [
+                    {
+                      "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                      "accountName": "The Siam Residences, Bangkok",
+                      "accountEmail": "reservations@thesiamresidences.com",
+                      "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                      "amountDue": {
+                        "percent": 0.05
+                      },
+                      "sourceCurrency": "THB",
+                      "displayCurrency": "USD",
+                      "internalCurrency": "USD",
+                      "sourceAmount": 450,
+                      "displayAmount": 450,
+                      "internalAmount": 450,
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45,
+                      "pendingRefunds": [
+                        {
+                          "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45
+                        }
+                      ],
+                      "netSourceAmount": 450,
+                      "netDisplayAmount": 450,
+                      "netInternalAmount": 450,
+                      "reconciled": false
+                    }
+                  ]
                 }
               }
             }
@@ -7378,8 +7378,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -7389,8 +7389,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -7797,8 +7797,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -7808,8 +7808,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -7949,8 +7949,8 @@
                                 "email": "johnsmith@email.com",
                                 "secondaryEmail": "johnsmith2@email.com",
                                 "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                               }
                             ],
                             "petInfo": [
@@ -8410,6 +8410,208 @@
                         "currency": "USD"
                       }
                     ],
+                    "guestUser": {
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "reservations@thesiamresidences.com",
+                      "telephone": "+1 212 555 1212",
+                      "profile": {
+                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                        "createdDate": "2026-01-14T09:30:00",
+                        "lastUpdate": "2026-02-03T16:45:12",
+                        "version": 3,
+                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "share": true,
+                        "user": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "alexandra@beaumont.com",
+                          "phone": "+66212658866",
+                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                          "fullName": "Alexandra Beaumont"
+                        },
+                        "personal": {
+                          "gender": "FEMALE",
+                          "birthDate": "1985-06-15",
+                          "maritalStatus": "MARRIED",
+                          "childQuantity": 2,
+                          "citizenship": "Thailand",
+                          "address1": "123 Petchburi Road",
+                          "address2": "Ratchathewi District",
+                          "city": "Bangkok",
+                          "state": "Bangkok",
+                          "postalCode": "10400",
+                          "country": "TH",
+                          "preferredCurrency": "USD",
+                          "language": "en",
+                          "contactPerson": [
+                            {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            }
+                          ],
+                          "petInfo": [
+                            {
+                              "name": "Luna",
+                              "type": "Golden Retriever"
+                            }
+                          ]
+                        },
+                        "preferences": {
+                          "propertyLocationPref": "Beachfront",
+                          "propertyTypePref": "Luxury Resort",
+                          "hotelChainPref": "Mandarin Oriental",
+                          "physChalFeaturePref": "Wheelchair accessible rooms",
+                          "smokingAllowed": false,
+                          "roomLocationPref": "High floor with city view",
+                          "bedTypePref": "King bed",
+                          "foodSrvcPref": "In-room dining",
+                          "guestType": "Business traveler",
+                          "mealPref": "Continental breakfast",
+                          "cuisinePref": "Thai"
+                        }
+                      },
+                      "fullName": "Alexandra Beaumont"
+                    },
+                    "ancillaryList": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
                     "meetingRooms": [
                       {
                         "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -8480,8 +8682,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -8491,8 +8693,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -8612,8 +8814,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -8623,8 +8825,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -8744,8 +8946,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -8755,8 +8957,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -8876,8 +9078,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -8887,8 +9089,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -9008,8 +9210,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -9019,8 +9221,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -9140,8 +9342,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -9151,8 +9353,140 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "roomTypeAncillaries": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -9272,8 +9606,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -9283,242 +9617,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ],
-                    "guestUser": {
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "reservations@thesiamresidences.com",
-                      "telephone": "+1 212 555 1212",
-                      "profile": {
-                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                        "createdDate": "2026-01-14T09:30:00",
-                        "lastUpdate": "2026-02-03T16:45:12",
-                        "version": 3,
-                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "share": true,
-                        "user": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "alexandra@beaumont.com",
-                          "phone": "+66212658866",
-                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "personal": {
-                          "gender": "FEMALE",
-                          "birthDate": "1985-06-15",
-                          "maritalStatus": "MARRIED",
-                          "childQuantity": 2,
-                          "citizenship": "Thailand",
-                          "address1": "123 Petchburi Road",
-                          "address2": "Ratchathewi District",
-                          "city": "Bangkok",
-                          "state": "Bangkok",
-                          "postalCode": "10400",
-                          "country": "TH",
-                          "preferredCurrency": "USD",
-                          "language": "en",
-                          "contactPerson": [
-                            {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            }
-                          ],
-                          "petInfo": [
-                            {
-                              "name": "Luna",
-                              "type": "Golden Retriever"
-                            }
-                          ]
-                        },
-                        "preferences": {
-                          "propertyLocationPref": "Beachfront",
-                          "propertyTypePref": "Luxury Resort",
-                          "hotelChainPref": "Mandarin Oriental",
-                          "physChalFeaturePref": "Wheelchair accessible rooms",
-                          "smokingAllowed": false,
-                          "roomLocationPref": "High floor with city view",
-                          "bedTypePref": "King bed",
-                          "foodSrvcPref": "In-room dining",
-                          "guestType": "Business traveler",
-                          "mealPref": "Continental breakfast",
-                          "cuisinePref": "Thai"
-                        }
-                      },
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "ancillaryList": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -9569,142 +9669,6 @@
                       }
                     ],
                     "cancellable": false,
-                    "roomTypeAncillaries": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "totalPaymentProcessingFeeSourceAmount": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
                     "netTotalSalesSourceAmountOrZero": {
                       "amount": 1250,
                       "currency": "USD"
@@ -9714,6 +9678,10 @@
                       "currency": "USD"
                     },
                     "totalPlatformFeeSourceAmount": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "totalPaymentProcessingFeeSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -9728,7 +9696,39 @@
                     "totalSupplierAgencyFeesSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
-                    }
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
                   }
                 ]
               }
@@ -10089,8 +10089,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -10100,8 +10100,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -10508,8 +10508,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -10519,8 +10519,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -10660,8 +10660,8 @@
                                 "email": "johnsmith@email.com",
                                 "secondaryEmail": "johnsmith2@email.com",
                                 "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                               }
                             ],
                             "petInfo": [
@@ -11121,6 +11121,208 @@
                         "currency": "USD"
                       }
                     ],
+                    "guestUser": {
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "reservations@thesiamresidences.com",
+                      "telephone": "+1 212 555 1212",
+                      "profile": {
+                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                        "createdDate": "2026-01-14T09:30:00",
+                        "lastUpdate": "2026-02-03T16:45:12",
+                        "version": 3,
+                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "share": true,
+                        "user": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "alexandra@beaumont.com",
+                          "phone": "+66212658866",
+                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                          "fullName": "Alexandra Beaumont"
+                        },
+                        "personal": {
+                          "gender": "FEMALE",
+                          "birthDate": "1985-06-15",
+                          "maritalStatus": "MARRIED",
+                          "childQuantity": 2,
+                          "citizenship": "Thailand",
+                          "address1": "123 Petchburi Road",
+                          "address2": "Ratchathewi District",
+                          "city": "Bangkok",
+                          "state": "Bangkok",
+                          "postalCode": "10400",
+                          "country": "TH",
+                          "preferredCurrency": "USD",
+                          "language": "en",
+                          "contactPerson": [
+                            {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            }
+                          ],
+                          "petInfo": [
+                            {
+                              "name": "Luna",
+                              "type": "Golden Retriever"
+                            }
+                          ]
+                        },
+                        "preferences": {
+                          "propertyLocationPref": "Beachfront",
+                          "propertyTypePref": "Luxury Resort",
+                          "hotelChainPref": "Mandarin Oriental",
+                          "physChalFeaturePref": "Wheelchair accessible rooms",
+                          "smokingAllowed": false,
+                          "roomLocationPref": "High floor with city view",
+                          "bedTypePref": "King bed",
+                          "foodSrvcPref": "In-room dining",
+                          "guestType": "Business traveler",
+                          "mealPref": "Continental breakfast",
+                          "cuisinePref": "Thai"
+                        }
+                      },
+                      "fullName": "Alexandra Beaumont"
+                    },
+                    "ancillaryList": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
                     "meetingRooms": [
                       {
                         "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -11191,8 +11393,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11202,8 +11404,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -11323,8 +11525,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11334,8 +11536,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -11455,8 +11657,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11466,8 +11668,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -11587,8 +11789,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11598,8 +11800,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -11719,8 +11921,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11730,8 +11932,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -11851,8 +12053,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11862,8 +12064,140 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "roomTypeAncillaries": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -11983,8 +12317,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -11994,242 +12328,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ],
-                    "guestUser": {
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "reservations@thesiamresidences.com",
-                      "telephone": "+1 212 555 1212",
-                      "profile": {
-                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                        "createdDate": "2026-01-14T09:30:00",
-                        "lastUpdate": "2026-02-03T16:45:12",
-                        "version": 3,
-                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "share": true,
-                        "user": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "alexandra@beaumont.com",
-                          "phone": "+66212658866",
-                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "personal": {
-                          "gender": "FEMALE",
-                          "birthDate": "1985-06-15",
-                          "maritalStatus": "MARRIED",
-                          "childQuantity": 2,
-                          "citizenship": "Thailand",
-                          "address1": "123 Petchburi Road",
-                          "address2": "Ratchathewi District",
-                          "city": "Bangkok",
-                          "state": "Bangkok",
-                          "postalCode": "10400",
-                          "country": "TH",
-                          "preferredCurrency": "USD",
-                          "language": "en",
-                          "contactPerson": [
-                            {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            }
-                          ],
-                          "petInfo": [
-                            {
-                              "name": "Luna",
-                              "type": "Golden Retriever"
-                            }
-                          ]
-                        },
-                        "preferences": {
-                          "propertyLocationPref": "Beachfront",
-                          "propertyTypePref": "Luxury Resort",
-                          "hotelChainPref": "Mandarin Oriental",
-                          "physChalFeaturePref": "Wheelchair accessible rooms",
-                          "smokingAllowed": false,
-                          "roomLocationPref": "High floor with city view",
-                          "bedTypePref": "King bed",
-                          "foodSrvcPref": "In-room dining",
-                          "guestType": "Business traveler",
-                          "mealPref": "Continental breakfast",
-                          "cuisinePref": "Thai"
-                        }
-                      },
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "ancillaryList": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -12280,142 +12380,6 @@
                       }
                     ],
                     "cancellable": false,
-                    "roomTypeAncillaries": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "totalPaymentProcessingFeeSourceAmount": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
                     "netTotalSalesSourceAmountOrZero": {
                       "amount": 1250,
                       "currency": "USD"
@@ -12425,6 +12389,10 @@
                       "currency": "USD"
                     },
                     "totalPlatformFeeSourceAmount": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "totalPaymentProcessingFeeSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -12439,7 +12407,39 @@
                     "totalSupplierAgencyFeesSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
-                    }
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
                   }
                 ]
               }
@@ -14336,8 +14336,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -14347,8 +14347,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -14755,8 +14755,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -14766,8 +14766,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -14907,8 +14907,8 @@
                                 "email": "johnsmith@email.com",
                                 "secondaryEmail": "johnsmith2@email.com",
                                 "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                               }
                             ],
                             "petInfo": [
@@ -15368,6 +15368,208 @@
                         "currency": "USD"
                       }
                     ],
+                    "guestUser": {
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "reservations@thesiamresidences.com",
+                      "telephone": "+1 212 555 1212",
+                      "profile": {
+                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                        "createdDate": "2026-01-14T09:30:00",
+                        "lastUpdate": "2026-02-03T16:45:12",
+                        "version": 3,
+                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "share": true,
+                        "user": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "alexandra@beaumont.com",
+                          "phone": "+66212658866",
+                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                          "fullName": "Alexandra Beaumont"
+                        },
+                        "personal": {
+                          "gender": "FEMALE",
+                          "birthDate": "1985-06-15",
+                          "maritalStatus": "MARRIED",
+                          "childQuantity": 2,
+                          "citizenship": "Thailand",
+                          "address1": "123 Petchburi Road",
+                          "address2": "Ratchathewi District",
+                          "city": "Bangkok",
+                          "state": "Bangkok",
+                          "postalCode": "10400",
+                          "country": "TH",
+                          "preferredCurrency": "USD",
+                          "language": "en",
+                          "contactPerson": [
+                            {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            }
+                          ],
+                          "petInfo": [
+                            {
+                              "name": "Luna",
+                              "type": "Golden Retriever"
+                            }
+                          ]
+                        },
+                        "preferences": {
+                          "propertyLocationPref": "Beachfront",
+                          "propertyTypePref": "Luxury Resort",
+                          "hotelChainPref": "Mandarin Oriental",
+                          "physChalFeaturePref": "Wheelchair accessible rooms",
+                          "smokingAllowed": false,
+                          "roomLocationPref": "High floor with city view",
+                          "bedTypePref": "King bed",
+                          "foodSrvcPref": "In-room dining",
+                          "guestType": "Business traveler",
+                          "mealPref": "Continental breakfast",
+                          "cuisinePref": "Thai"
+                        }
+                      },
+                      "fullName": "Alexandra Beaumont"
+                    },
+                    "ancillaryList": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
                     "meetingRooms": [
                       {
                         "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -15438,8 +15640,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -15449,8 +15651,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -15570,8 +15772,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -15581,8 +15783,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -15702,8 +15904,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -15713,8 +15915,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -15834,8 +16036,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -15845,8 +16047,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -15966,8 +16168,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -15977,8 +16179,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -16098,8 +16300,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -16109,8 +16311,140 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "roomTypeAncillaries": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -16230,8 +16564,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -16241,242 +16575,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ],
-                    "guestUser": {
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "reservations@thesiamresidences.com",
-                      "telephone": "+1 212 555 1212",
-                      "profile": {
-                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                        "createdDate": "2026-01-14T09:30:00",
-                        "lastUpdate": "2026-02-03T16:45:12",
-                        "version": 3,
-                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "share": true,
-                        "user": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "alexandra@beaumont.com",
-                          "phone": "+66212658866",
-                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "personal": {
-                          "gender": "FEMALE",
-                          "birthDate": "1985-06-15",
-                          "maritalStatus": "MARRIED",
-                          "childQuantity": 2,
-                          "citizenship": "Thailand",
-                          "address1": "123 Petchburi Road",
-                          "address2": "Ratchathewi District",
-                          "city": "Bangkok",
-                          "state": "Bangkok",
-                          "postalCode": "10400",
-                          "country": "TH",
-                          "preferredCurrency": "USD",
-                          "language": "en",
-                          "contactPerson": [
-                            {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            }
-                          ],
-                          "petInfo": [
-                            {
-                              "name": "Luna",
-                              "type": "Golden Retriever"
-                            }
-                          ]
-                        },
-                        "preferences": {
-                          "propertyLocationPref": "Beachfront",
-                          "propertyTypePref": "Luxury Resort",
-                          "hotelChainPref": "Mandarin Oriental",
-                          "physChalFeaturePref": "Wheelchair accessible rooms",
-                          "smokingAllowed": false,
-                          "roomLocationPref": "High floor with city view",
-                          "bedTypePref": "King bed",
-                          "foodSrvcPref": "In-room dining",
-                          "guestType": "Business traveler",
-                          "mealPref": "Continental breakfast",
-                          "cuisinePref": "Thai"
-                        }
-                      },
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "ancillaryList": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -16527,142 +16627,6 @@
                       }
                     ],
                     "cancellable": false,
-                    "roomTypeAncillaries": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "totalPaymentProcessingFeeSourceAmount": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
                     "netTotalSalesSourceAmountOrZero": {
                       "amount": 1250,
                       "currency": "USD"
@@ -16672,6 +16636,10 @@
                       "currency": "USD"
                     },
                     "totalPlatformFeeSourceAmount": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "totalPaymentProcessingFeeSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -16686,7 +16654,39 @@
                     "totalSupplierAgencyFeesSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
-                    }
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
                   }
                 ]
               }
@@ -17038,8 +17038,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -17049,8 +17049,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -17457,8 +17457,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -17468,8 +17468,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -17609,8 +17609,8 @@
                                 "email": "johnsmith@email.com",
                                 "secondaryEmail": "johnsmith2@email.com",
                                 "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                               }
                             ],
                             "petInfo": [
@@ -18070,6 +18070,208 @@
                         "currency": "USD"
                       }
                     ],
+                    "guestUser": {
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "reservations@thesiamresidences.com",
+                      "telephone": "+1 212 555 1212",
+                      "profile": {
+                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                        "createdDate": "2026-01-14T09:30:00",
+                        "lastUpdate": "2026-02-03T16:45:12",
+                        "version": 3,
+                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "share": true,
+                        "user": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "alexandra@beaumont.com",
+                          "phone": "+66212658866",
+                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                          "fullName": "Alexandra Beaumont"
+                        },
+                        "personal": {
+                          "gender": "FEMALE",
+                          "birthDate": "1985-06-15",
+                          "maritalStatus": "MARRIED",
+                          "childQuantity": 2,
+                          "citizenship": "Thailand",
+                          "address1": "123 Petchburi Road",
+                          "address2": "Ratchathewi District",
+                          "city": "Bangkok",
+                          "state": "Bangkok",
+                          "postalCode": "10400",
+                          "country": "TH",
+                          "preferredCurrency": "USD",
+                          "language": "en",
+                          "contactPerson": [
+                            {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            }
+                          ],
+                          "petInfo": [
+                            {
+                              "name": "Luna",
+                              "type": "Golden Retriever"
+                            }
+                          ]
+                        },
+                        "preferences": {
+                          "propertyLocationPref": "Beachfront",
+                          "propertyTypePref": "Luxury Resort",
+                          "hotelChainPref": "Mandarin Oriental",
+                          "physChalFeaturePref": "Wheelchair accessible rooms",
+                          "smokingAllowed": false,
+                          "roomLocationPref": "High floor with city view",
+                          "bedTypePref": "King bed",
+                          "foodSrvcPref": "In-room dining",
+                          "guestType": "Business traveler",
+                          "mealPref": "Continental breakfast",
+                          "cuisinePref": "Thai"
+                        }
+                      },
+                      "fullName": "Alexandra Beaumont"
+                    },
+                    "ancillaryList": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
                     "meetingRooms": [
                       {
                         "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -18140,8 +18342,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18151,8 +18353,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -18272,8 +18474,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18283,8 +18485,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -18404,8 +18606,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18415,8 +18617,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -18536,8 +18738,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18547,8 +18749,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -18668,8 +18870,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18679,8 +18881,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -18800,8 +19002,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18811,8 +19013,140 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "roomTypeAncillaries": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -18932,8 +19266,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -18943,242 +19277,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ],
-                    "guestUser": {
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "reservations@thesiamresidences.com",
-                      "telephone": "+1 212 555 1212",
-                      "profile": {
-                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                        "createdDate": "2026-01-14T09:30:00",
-                        "lastUpdate": "2026-02-03T16:45:12",
-                        "version": 3,
-                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "share": true,
-                        "user": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "alexandra@beaumont.com",
-                          "phone": "+66212658866",
-                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "personal": {
-                          "gender": "FEMALE",
-                          "birthDate": "1985-06-15",
-                          "maritalStatus": "MARRIED",
-                          "childQuantity": 2,
-                          "citizenship": "Thailand",
-                          "address1": "123 Petchburi Road",
-                          "address2": "Ratchathewi District",
-                          "city": "Bangkok",
-                          "state": "Bangkok",
-                          "postalCode": "10400",
-                          "country": "TH",
-                          "preferredCurrency": "USD",
-                          "language": "en",
-                          "contactPerson": [
-                            {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            }
-                          ],
-                          "petInfo": [
-                            {
-                              "name": "Luna",
-                              "type": "Golden Retriever"
-                            }
-                          ]
-                        },
-                        "preferences": {
-                          "propertyLocationPref": "Beachfront",
-                          "propertyTypePref": "Luxury Resort",
-                          "hotelChainPref": "Mandarin Oriental",
-                          "physChalFeaturePref": "Wheelchair accessible rooms",
-                          "smokingAllowed": false,
-                          "roomLocationPref": "High floor with city view",
-                          "bedTypePref": "King bed",
-                          "foodSrvcPref": "In-room dining",
-                          "guestType": "Business traveler",
-                          "mealPref": "Continental breakfast",
-                          "cuisinePref": "Thai"
-                        }
-                      },
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "ancillaryList": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -19229,142 +19329,6 @@
                       }
                     ],
                     "cancellable": false,
-                    "roomTypeAncillaries": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "totalPaymentProcessingFeeSourceAmount": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
                     "netTotalSalesSourceAmountOrZero": {
                       "amount": 1250,
                       "currency": "USD"
@@ -19374,6 +19338,10 @@
                       "currency": "USD"
                     },
                     "totalPlatformFeeSourceAmount": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "totalPaymentProcessingFeeSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -19388,7 +19356,39 @@
                     "totalSupplierAgencyFeesSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
-                    }
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
                   }
                 ]
               }
@@ -19740,8 +19740,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -19751,8 +19751,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "commissionable": true,
                         "name": "Archery lesson",
@@ -20159,8 +20159,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -20170,8 +20170,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -20311,8 +20311,8 @@
                                 "email": "johnsmith@email.com",
                                 "secondaryEmail": "johnsmith2@email.com",
                                 "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                               }
                             ],
                             "petInfo": [
@@ -20772,6 +20772,208 @@
                         "currency": "USD"
                       }
                     ],
+                    "guestUser": {
+                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                      "firstName": "Alexandra",
+                      "lastName": "Beaumont",
+                      "email": "reservations@thesiamresidences.com",
+                      "telephone": "+1 212 555 1212",
+                      "profile": {
+                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                        "createdDate": "2026-01-14T09:30:00",
+                        "lastUpdate": "2026-02-03T16:45:12",
+                        "version": 3,
+                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "share": true,
+                        "user": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "alexandra@beaumont.com",
+                          "phone": "+66212658866",
+                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                          "fullName": "Alexandra Beaumont"
+                        },
+                        "personal": {
+                          "gender": "FEMALE",
+                          "birthDate": "1985-06-15",
+                          "maritalStatus": "MARRIED",
+                          "childQuantity": 2,
+                          "citizenship": "Thailand",
+                          "address1": "123 Petchburi Road",
+                          "address2": "Ratchathewi District",
+                          "city": "Bangkok",
+                          "state": "Bangkok",
+                          "postalCode": "10400",
+                          "country": "TH",
+                          "preferredCurrency": "USD",
+                          "language": "en",
+                          "contactPerson": [
+                            {
+                              "firstName": "Alexandra",
+                              "lastName": "Beaumont",
+                              "email": "johnsmith@email.com",
+                              "secondaryEmail": "johnsmith2@email.com",
+                              "phoneNumber": "+12125551212",
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                            }
+                          ],
+                          "petInfo": [
+                            {
+                              "name": "Luna",
+                              "type": "Golden Retriever"
+                            }
+                          ]
+                        },
+                        "preferences": {
+                          "propertyLocationPref": "Beachfront",
+                          "propertyTypePref": "Luxury Resort",
+                          "hotelChainPref": "Mandarin Oriental",
+                          "physChalFeaturePref": "Wheelchair accessible rooms",
+                          "smokingAllowed": false,
+                          "roomLocationPref": "High floor with city view",
+                          "bedTypePref": "King bed",
+                          "foodSrvcPref": "In-room dining",
+                          "guestType": "Business traveler",
+                          "mealPref": "Continental breakfast",
+                          "cuisinePref": "Thai"
+                        }
+                      },
+                      "fullName": "Alexandra Beaumont"
+                    },
+                    "ancillaryList": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
                     "meetingRooms": [
                       {
                         "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -20842,8 +21044,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -20853,8 +21055,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -20974,8 +21176,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -20985,8 +21187,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -21106,8 +21308,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -21117,8 +21319,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -21238,8 +21440,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -21249,8 +21451,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -21370,8 +21572,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -21381,8 +21583,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -21502,8 +21704,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -21513,8 +21715,140 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                        },
+                        "financialBreakdown": {
+                          "displayPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "internalPriceQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "beneficiaryList": [
+                            {
+                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                              "accountName": "The Siam Residences, Bangkok",
+                              "accountEmail": "reservations@thesiamresidences.com",
+                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                              "amountDue": {
+                                "percent": 0.05
+                              },
+                              "sourceCurrency": "THB",
+                              "displayCurrency": "USD",
+                              "internalCurrency": "USD",
+                              "sourceAmount": 450,
+                              "displayAmount": 450,
+                              "internalAmount": 450,
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45,
+                              "pendingRefunds": [
+                                {
+                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                  "sourceAmountRefundModifier": 45,
+                                  "displayAmountRefundModifier": 45,
+                                  "internalAmountRefundModifier": 45
+                                }
+                              ],
+                              "netSourceAmount": 450,
+                              "netDisplayAmount": 450,
+                              "netInternalAmount": 450,
+                              "reconciled": false
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "roomTypeAncillaries": [
+                      {
+                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                        "name": "Thai Massage Spa Treatment",
+                        "pricingType": "PER_USE",
+                        "type": "ADD_ON",
+                        "price": {
+                          "sourceToUserCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "sourceToInternalCurrencyQuote": {
+                            "source": "USD",
+                            "target": "THB",
+                            "exchangeRate": 33.5,
+                            "timestamp": 1705233000000
+                          },
+                          "userSpecifiedCurrencyBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "sourceBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalBaseTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyPromotionalModifier": -40,
+                          "sourcePromotionalModifier": -40,
+                          "internalPromotionalModifier": -40,
+                          "userSpecifiedCurrencyPremiumModifier": 40,
+                          "sourcePremiumModifier": 40,
+                          "internalPremiumModifier": 40,
+                          "userSpecifiedCurrencyChannelModifier": -10,
+                          "sourceChannelModifier": -10,
+                          "internalChannelModifier": -10,
+                          "quantity": 1,
+                          "sourceTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "internalTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          },
+                          "userSpecifiedCurrencyTotal": {
+                            "amount": 1250,
+                            "currency": "USD"
+                          }
+                        },
+                        "startDate": "2017-12-22T03:07:58.742+0000",
+                        "endDate": "2017-12-22T08:07:58.742+0000",
+                        "attendees": 2,
+                        "imageIdentifier": "cloudinary-image-1",
+                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                        "localizedName": "Plass 1",
+                        "localizedDescription": "place-1",
+                        "contact": {
+                          "firstName": "Alexandra",
+                          "lastName": "Beaumont",
+                          "email": "johnsmith@email.com",
+                          "secondaryEmail": "johnsmith2@email.com",
+                          "phoneNumber": "+12125551212",
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                        },
+                        "address": {
+                          "address1": "234 Near da beach",
+                          "address2": "Pebble #5001",
+                          "state": "CA",
+                          "postalCode": "90210",
+                          "county": "Alameda county",
+                          "city": "Bangkok",
+                          "countryCode": "TH",
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -21634,8 +21968,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         },
                         "address": {
                           "address1": "234 Near da beach",
@@ -21645,242 +21979,8 @@
                           "county": "Alameda county",
                           "city": "Bangkok",
                           "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ],
-                    "guestUser": {
-                      "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                      "firstName": "Alexandra",
-                      "lastName": "Beaumont",
-                      "email": "reservations@thesiamresidences.com",
-                      "telephone": "+1 212 555 1212",
-                      "profile": {
-                        "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                        "createdDate": "2026-01-14T09:30:00",
-                        "lastUpdate": "2026-02-03T16:45:12",
-                        "version": 3,
-                        "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "share": true,
-                        "user": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "alexandra@beaumont.com",
-                          "phone": "+66212658866",
-                          "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "personal": {
-                          "gender": "FEMALE",
-                          "birthDate": "1985-06-15",
-                          "maritalStatus": "MARRIED",
-                          "childQuantity": 2,
-                          "citizenship": "Thailand",
-                          "address1": "123 Petchburi Road",
-                          "address2": "Ratchathewi District",
-                          "city": "Bangkok",
-                          "state": "Bangkok",
-                          "postalCode": "10400",
-                          "country": "TH",
-                          "preferredCurrency": "USD",
-                          "language": "en",
-                          "contactPerson": [
-                            {
-                              "firstName": "Alexandra",
-                              "lastName": "Beaumont",
-                              "email": "johnsmith@email.com",
-                              "secondaryEmail": "johnsmith2@email.com",
-                              "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
-                            }
-                          ],
-                          "petInfo": [
-                            {
-                              "name": "Luna",
-                              "type": "Golden Retriever"
-                            }
-                          ]
-                        },
-                        "preferences": {
-                          "propertyLocationPref": "Beachfront",
-                          "propertyTypePref": "Luxury Resort",
-                          "hotelChainPref": "Mandarin Oriental",
-                          "physChalFeaturePref": "Wheelchair accessible rooms",
-                          "smokingAllowed": false,
-                          "roomLocationPref": "High floor with city view",
-                          "bedTypePref": "King bed",
-                          "foodSrvcPref": "In-room dining",
-                          "guestType": "Business traveler",
-                          "mealPref": "Continental breakfast",
-                          "cuisinePref": "Thai"
-                        }
-                      },
-                      "fullName": "Alexandra Beaumont"
-                    },
-                    "ancillaryList": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
+                          "country": "United States",
+                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                         },
                         "financialBreakdown": {
                           "displayPriceQuote": {
@@ -21931,142 +22031,6 @@
                       }
                     ],
                     "cancellable": false,
-                    "roomTypeAncillaries": [
-                      {
-                        "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                        "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                        "name": "Thai Massage Spa Treatment",
-                        "pricingType": "PER_USE",
-                        "type": "ADD_ON",
-                        "price": {
-                          "sourceToUserCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "sourceToInternalCurrencyQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "userSpecifiedCurrencyBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "sourceBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalBaseTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyPromotionalModifier": -40,
-                          "sourcePromotionalModifier": -40,
-                          "internalPromotionalModifier": -40,
-                          "userSpecifiedCurrencyPremiumModifier": 40,
-                          "sourcePremiumModifier": 40,
-                          "internalPremiumModifier": 40,
-                          "userSpecifiedCurrencyChannelModifier": -10,
-                          "sourceChannelModifier": -10,
-                          "internalChannelModifier": -10,
-                          "quantity": 1,
-                          "sourceTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "internalTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          },
-                          "userSpecifiedCurrencyTotal": {
-                            "amount": 1250,
-                            "currency": "USD"
-                          }
-                        },
-                        "startDate": "2017-12-22T03:07:58.742+0000",
-                        "endDate": "2017-12-22T08:07:58.742+0000",
-                        "attendees": 2,
-                        "imageIdentifier": "cloudinary-image-1",
-                        "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                        "localizedName": "Plass 1",
-                        "localizedDescription": "place-1",
-                        "contact": {
-                          "firstName": "Alexandra",
-                          "lastName": "Beaumont",
-                          "email": "johnsmith@email.com",
-                          "secondaryEmail": "johnsmith2@email.com",
-                          "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
-                        },
-                        "address": {
-                          "address1": "234 Near da beach",
-                          "address2": "Pebble #5001",
-                          "state": "CA",
-                          "postalCode": "90210",
-                          "county": "Alameda county",
-                          "city": "Bangkok",
-                          "countryCode": "TH",
-                          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                          "country": "United States"
-                        },
-                        "financialBreakdown": {
-                          "displayPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "internalPriceQuote": {
-                            "source": "USD",
-                            "target": "THB",
-                            "exchangeRate": 33.5,
-                            "timestamp": 1705233000000
-                          },
-                          "beneficiaryList": [
-                            {
-                              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                              "accountName": "The Siam Residences, Bangkok",
-                              "accountEmail": "reservations@thesiamresidences.com",
-                              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                              "amountDue": {
-                                "percent": 0.05
-                              },
-                              "sourceCurrency": "THB",
-                              "displayCurrency": "USD",
-                              "internalCurrency": "USD",
-                              "sourceAmount": 450,
-                              "displayAmount": 450,
-                              "internalAmount": 450,
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45,
-                              "pendingRefunds": [
-                                {
-                                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                  "sourceAmountRefundModifier": 45,
-                                  "displayAmountRefundModifier": 45,
-                                  "internalAmountRefundModifier": 45
-                                }
-                              ],
-                              "netSourceAmount": 450,
-                              "netDisplayAmount": 450,
-                              "netInternalAmount": 450,
-                              "reconciled": false
-                            }
-                          ]
-                        }
-                      }
-                    ],
-                    "totalPaymentProcessingFeeSourceAmount": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
                     "netTotalSalesSourceAmountOrZero": {
                       "amount": 1250,
                       "currency": "USD"
@@ -22076,6 +22040,10 @@
                       "currency": "USD"
                     },
                     "totalPlatformFeeSourceAmount": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "totalPaymentProcessingFeeSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
                     },
@@ -22090,7 +22058,39 @@
                     "totalSupplierAgencyFeesSourceAmount": {
                       "amount": 1250,
                       "currency": "USD"
-                    }
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
                   }
                 ]
               }
@@ -22441,8 +22441,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -22452,8 +22452,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -22860,8 +22860,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -22871,8 +22871,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -23012,8 +23012,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 }
                               ],
                               "petInfo": [
@@ -23473,6 +23473,208 @@
                           "currency": "USD"
                         }
                       ],
+                      "guestUser": {
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "reservations@thesiamresidences.com",
+                        "telephone": "+1 212 555 1212",
+                        "profile": {
+                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                          "createdDate": "2026-01-14T09:30:00",
+                          "lastUpdate": "2026-02-03T16:45:12",
+                          "version": 3,
+                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                          "share": true,
+                          "user": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "alexandra@beaumont.com",
+                            "phone": "+66212658866",
+                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                            "fullName": "Alexandra Beaumont"
+                          },
+                          "personal": {
+                            "gender": "FEMALE",
+                            "birthDate": "1985-06-15",
+                            "maritalStatus": "MARRIED",
+                            "childQuantity": 2,
+                            "citizenship": "Thailand",
+                            "address1": "123 Petchburi Road",
+                            "address2": "Ratchathewi District",
+                            "city": "Bangkok",
+                            "state": "Bangkok",
+                            "postalCode": "10400",
+                            "country": "TH",
+                            "preferredCurrency": "USD",
+                            "language": "en",
+                            "contactPerson": [
+                              {
+                                "firstName": "Alexandra",
+                                "lastName": "Beaumont",
+                                "email": "johnsmith@email.com",
+                                "secondaryEmail": "johnsmith2@email.com",
+                                "phoneNumber": "+12125551212",
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                              }
+                            ],
+                            "petInfo": [
+                              {
+                                "name": "Luna",
+                                "type": "Golden Retriever"
+                              }
+                            ]
+                          },
+                          "preferences": {
+                            "propertyLocationPref": "Beachfront",
+                            "propertyTypePref": "Luxury Resort",
+                            "hotelChainPref": "Mandarin Oriental",
+                            "physChalFeaturePref": "Wheelchair accessible rooms",
+                            "smokingAllowed": false,
+                            "roomLocationPref": "High floor with city view",
+                            "bedTypePref": "King bed",
+                            "foodSrvcPref": "In-room dining",
+                            "guestType": "Business traveler",
+                            "mealPref": "Continental breakfast",
+                            "cuisinePref": "Thai"
+                          }
+                        },
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "ancillaryList": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
                       "meetingRooms": [
                         {
                           "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -23543,8 +23745,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -23554,8 +23756,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -23675,8 +23877,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -23686,8 +23888,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -23807,8 +24009,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -23818,8 +24020,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -23939,8 +24141,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -23950,8 +24152,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -24071,8 +24273,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -24082,8 +24284,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -24203,8 +24405,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -24214,8 +24416,140 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "roomTypeAncillaries": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -24335,8 +24669,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -24346,242 +24680,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ],
-                      "guestUser": {
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "reservations@thesiamresidences.com",
-                        "telephone": "+1 212 555 1212",
-                        "profile": {
-                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                          "createdDate": "2026-01-14T09:30:00",
-                          "lastUpdate": "2026-02-03T16:45:12",
-                          "version": 3,
-                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                          "share": true,
-                          "user": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "alexandra@beaumont.com",
-                            "phone": "+66212658866",
-                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "personal": {
-                            "gender": "FEMALE",
-                            "birthDate": "1985-06-15",
-                            "maritalStatus": "MARRIED",
-                            "childQuantity": 2,
-                            "citizenship": "Thailand",
-                            "address1": "123 Petchburi Road",
-                            "address2": "Ratchathewi District",
-                            "city": "Bangkok",
-                            "state": "Bangkok",
-                            "postalCode": "10400",
-                            "country": "TH",
-                            "preferredCurrency": "USD",
-                            "language": "en",
-                            "contactPerson": [
-                              {
-                                "firstName": "Alexandra",
-                                "lastName": "Beaumont",
-                                "email": "johnsmith@email.com",
-                                "secondaryEmail": "johnsmith2@email.com",
-                                "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
-                              }
-                            ],
-                            "petInfo": [
-                              {
-                                "name": "Luna",
-                                "type": "Golden Retriever"
-                              }
-                            ]
-                          },
-                          "preferences": {
-                            "propertyLocationPref": "Beachfront",
-                            "propertyTypePref": "Luxury Resort",
-                            "hotelChainPref": "Mandarin Oriental",
-                            "physChalFeaturePref": "Wheelchair accessible rooms",
-                            "smokingAllowed": false,
-                            "roomLocationPref": "High floor with city view",
-                            "bedTypePref": "King bed",
-                            "foodSrvcPref": "In-room dining",
-                            "guestType": "Business traveler",
-                            "mealPref": "Continental breakfast",
-                            "cuisinePref": "Thai"
-                          }
-                        },
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "ancillaryList": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -24632,142 +24732,6 @@
                         }
                       ],
                       "cancellable": false,
-                      "roomTypeAncillaries": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "totalPaymentProcessingFeeSourceAmount": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
                       "netTotalSalesSourceAmountOrZero": {
                         "amount": 1250,
                         "currency": "USD"
@@ -24777,6 +24741,10 @@
                         "currency": "USD"
                       },
                       "totalPlatformFeeSourceAmount": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "totalPaymentProcessingFeeSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
                       },
@@ -24791,7 +24759,39 @@
                       "totalSupplierAgencyFeesSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
-                      }
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
                     }
                   ],
                   "number": 0,
@@ -25961,8 +25961,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -25972,8 +25972,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "commissionable": true,
                           "name": "Archery lesson",
@@ -26380,8 +26380,8 @@
                               "email": "johnsmith@email.com",
                               "secondaryEmail": "johnsmith2@email.com",
                               "phoneNumber": "+12125551212",
-                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                              "fullName": "Alexandra Beaumont"
+                              "fullName": "Alexandra Beaumont",
+                              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                             },
                             "address": {
                               "address1": "234 Near da beach",
@@ -26391,8 +26391,8 @@
                               "county": "Alameda county",
                               "city": "Bangkok",
                               "countryCode": "TH",
-                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                              "country": "United States"
+                              "country": "United States",
+                              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                             },
                             "financialBreakdown": {
                               "displayPriceQuote": {
@@ -26532,8 +26532,8 @@
                                   "email": "johnsmith@email.com",
                                   "secondaryEmail": "johnsmith2@email.com",
                                   "phoneNumber": "+12125551212",
-                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                  "fullName": "Alexandra Beaumont"
+                                  "fullName": "Alexandra Beaumont",
+                                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                                 }
                               ],
                               "petInfo": [
@@ -26993,6 +26993,208 @@
                           "currency": "USD"
                         }
                       ],
+                      "guestUser": {
+                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "reservations@thesiamresidences.com",
+                        "telephone": "+1 212 555 1212",
+                        "profile": {
+                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                          "createdDate": "2026-01-14T09:30:00",
+                          "lastUpdate": "2026-02-03T16:45:12",
+                          "version": 3,
+                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                          "share": true,
+                          "user": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "alexandra@beaumont.com",
+                            "phone": "+66212658866",
+                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                            "fullName": "Alexandra Beaumont"
+                          },
+                          "personal": {
+                            "gender": "FEMALE",
+                            "birthDate": "1985-06-15",
+                            "maritalStatus": "MARRIED",
+                            "childQuantity": 2,
+                            "citizenship": "Thailand",
+                            "address1": "123 Petchburi Road",
+                            "address2": "Ratchathewi District",
+                            "city": "Bangkok",
+                            "state": "Bangkok",
+                            "postalCode": "10400",
+                            "country": "TH",
+                            "preferredCurrency": "USD",
+                            "language": "en",
+                            "contactPerson": [
+                              {
+                                "firstName": "Alexandra",
+                                "lastName": "Beaumont",
+                                "email": "johnsmith@email.com",
+                                "secondaryEmail": "johnsmith2@email.com",
+                                "phoneNumber": "+12125551212",
+                                "fullName": "Alexandra Beaumont",
+                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                              }
+                            ],
+                            "petInfo": [
+                              {
+                                "name": "Luna",
+                                "type": "Golden Retriever"
+                              }
+                            ]
+                          },
+                          "preferences": {
+                            "propertyLocationPref": "Beachfront",
+                            "propertyTypePref": "Luxury Resort",
+                            "hotelChainPref": "Mandarin Oriental",
+                            "physChalFeaturePref": "Wheelchair accessible rooms",
+                            "smokingAllowed": false,
+                            "roomLocationPref": "High floor with city view",
+                            "bedTypePref": "King bed",
+                            "foodSrvcPref": "In-room dining",
+                            "guestType": "Business traveler",
+                            "mealPref": "Continental breakfast",
+                            "cuisinePref": "Thai"
+                          }
+                        },
+                        "fullName": "Alexandra Beaumont"
+                      },
+                      "ancillaryList": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
                       "meetingRooms": [
                         {
                           "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -27063,8 +27265,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27074,8 +27276,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -27195,8 +27397,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27206,8 +27408,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -27327,8 +27529,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27338,8 +27540,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -27459,8 +27661,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27470,8 +27672,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -27591,8 +27793,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27602,8 +27804,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -27723,8 +27925,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27734,8 +27936,140 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                          },
+                          "financialBreakdown": {
+                            "displayPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "internalPriceQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "beneficiaryList": [
+                              {
+                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                                "accountName": "The Siam Residences, Bangkok",
+                                "accountEmail": "reservations@thesiamresidences.com",
+                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                                "amountDue": {
+                                  "percent": 0.05
+                                },
+                                "sourceCurrency": "THB",
+                                "displayCurrency": "USD",
+                                "internalCurrency": "USD",
+                                "sourceAmount": 450,
+                                "displayAmount": 450,
+                                "internalAmount": 450,
+                                "sourceAmountRefundModifier": 45,
+                                "displayAmountRefundModifier": 45,
+                                "internalAmountRefundModifier": 45,
+                                "pendingRefunds": [
+                                  {
+                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                                    "sourceAmountRefundModifier": 45,
+                                    "displayAmountRefundModifier": 45,
+                                    "internalAmountRefundModifier": 45
+                                  }
+                                ],
+                                "netSourceAmount": 450,
+                                "netDisplayAmount": 450,
+                                "netInternalAmount": 450,
+                                "reconciled": false
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "roomTypeAncillaries": [
+                        {
+                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                          "name": "Thai Massage Spa Treatment",
+                          "pricingType": "PER_USE",
+                          "type": "ADD_ON",
+                          "price": {
+                            "sourceToUserCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "sourceToInternalCurrencyQuote": {
+                              "source": "USD",
+                              "target": "THB",
+                              "exchangeRate": 33.5,
+                              "timestamp": 1705233000000
+                            },
+                            "userSpecifiedCurrencyBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "sourceBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalBaseTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyPromotionalModifier": -40,
+                            "sourcePromotionalModifier": -40,
+                            "internalPromotionalModifier": -40,
+                            "userSpecifiedCurrencyPremiumModifier": 40,
+                            "sourcePremiumModifier": 40,
+                            "internalPremiumModifier": 40,
+                            "userSpecifiedCurrencyChannelModifier": -10,
+                            "sourceChannelModifier": -10,
+                            "internalChannelModifier": -10,
+                            "quantity": 1,
+                            "sourceTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "internalTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            },
+                            "userSpecifiedCurrencyTotal": {
+                              "amount": 1250,
+                              "currency": "USD"
+                            }
+                          },
+                          "startDate": "2017-12-22T03:07:58.742+0000",
+                          "endDate": "2017-12-22T08:07:58.742+0000",
+                          "attendees": 2,
+                          "imageIdentifier": "cloudinary-image-1",
+                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                          "localizedName": "Plass 1",
+                          "localizedDescription": "place-1",
+                          "contact": {
+                            "firstName": "Alexandra",
+                            "lastName": "Beaumont",
+                            "email": "johnsmith@email.com",
+                            "secondaryEmail": "johnsmith2@email.com",
+                            "phoneNumber": "+12125551212",
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                          },
+                          "address": {
+                            "address1": "234 Near da beach",
+                            "address2": "Pebble #5001",
+                            "state": "CA",
+                            "postalCode": "90210",
+                            "county": "Alameda county",
+                            "city": "Bangkok",
+                            "countryCode": "TH",
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -27855,8 +28189,8 @@
                             "email": "johnsmith@email.com",
                             "secondaryEmail": "johnsmith2@email.com",
                             "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
+                            "fullName": "Alexandra Beaumont",
+                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                           },
                           "address": {
                             "address1": "234 Near da beach",
@@ -27866,242 +28200,8 @@
                             "county": "Alameda county",
                             "city": "Bangkok",
                             "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "beneficiaryList": [
-                        {
-                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                          "accountName": "The Siam Residences, Bangkok",
-                          "accountEmail": "reservations@thesiamresidences.com",
-                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                          "amountDue": {
-                            "percent": 0.05
-                          },
-                          "sourceCurrency": "THB",
-                          "displayCurrency": "USD",
-                          "internalCurrency": "USD",
-                          "sourceAmount": 450,
-                          "displayAmount": 450,
-                          "internalAmount": 450,
-                          "sourceAmountRefundModifier": 45,
-                          "displayAmountRefundModifier": 45,
-                          "internalAmountRefundModifier": 45,
-                          "pendingRefunds": [
-                            {
-                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                              "sourceAmountRefundModifier": 45,
-                              "displayAmountRefundModifier": 45,
-                              "internalAmountRefundModifier": 45
-                            }
-                          ],
-                          "netSourceAmount": 450,
-                          "netDisplayAmount": 450,
-                          "netInternalAmount": 450,
-                          "reconciled": false
-                        }
-                      ],
-                      "guestUser": {
-                        "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "reservations@thesiamresidences.com",
-                        "telephone": "+1 212 555 1212",
-                        "profile": {
-                          "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                          "createdDate": "2026-01-14T09:30:00",
-                          "lastUpdate": "2026-02-03T16:45:12",
-                          "version": 3,
-                          "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                          "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                          "share": true,
-                          "user": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "alexandra@beaumont.com",
-                            "phone": "+66212658866",
-                            "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "personal": {
-                            "gender": "FEMALE",
-                            "birthDate": "1985-06-15",
-                            "maritalStatus": "MARRIED",
-                            "childQuantity": 2,
-                            "citizenship": "Thailand",
-                            "address1": "123 Petchburi Road",
-                            "address2": "Ratchathewi District",
-                            "city": "Bangkok",
-                            "state": "Bangkok",
-                            "postalCode": "10400",
-                            "country": "TH",
-                            "preferredCurrency": "USD",
-                            "language": "en",
-                            "contactPerson": [
-                              {
-                                "firstName": "Alexandra",
-                                "lastName": "Beaumont",
-                                "email": "johnsmith@email.com",
-                                "secondaryEmail": "johnsmith2@email.com",
-                                "phoneNumber": "+12125551212",
-                                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                                "fullName": "Alexandra Beaumont"
-                              }
-                            ],
-                            "petInfo": [
-                              {
-                                "name": "Luna",
-                                "type": "Golden Retriever"
-                              }
-                            ]
-                          },
-                          "preferences": {
-                            "propertyLocationPref": "Beachfront",
-                            "propertyTypePref": "Luxury Resort",
-                            "hotelChainPref": "Mandarin Oriental",
-                            "physChalFeaturePref": "Wheelchair accessible rooms",
-                            "smokingAllowed": false,
-                            "roomLocationPref": "High floor with city view",
-                            "bedTypePref": "King bed",
-                            "foodSrvcPref": "In-room dining",
-                            "guestType": "Business traveler",
-                            "mealPref": "Continental breakfast",
-                            "cuisinePref": "Thai"
-                          }
-                        },
-                        "fullName": "Alexandra Beaumont"
-                      },
-                      "ancillaryList": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
+                            "country": "United States",
+                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                           },
                           "financialBreakdown": {
                             "displayPriceQuote": {
@@ -28152,142 +28252,6 @@
                         }
                       ],
                       "cancellable": false,
-                      "roomTypeAncillaries": [
-                        {
-                          "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                          "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                          "name": "Thai Massage Spa Treatment",
-                          "pricingType": "PER_USE",
-                          "type": "ADD_ON",
-                          "price": {
-                            "sourceToUserCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "sourceToInternalCurrencyQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "userSpecifiedCurrencyBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "sourceBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalBaseTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyPromotionalModifier": -40,
-                            "sourcePromotionalModifier": -40,
-                            "internalPromotionalModifier": -40,
-                            "userSpecifiedCurrencyPremiumModifier": 40,
-                            "sourcePremiumModifier": 40,
-                            "internalPremiumModifier": 40,
-                            "userSpecifiedCurrencyChannelModifier": -10,
-                            "sourceChannelModifier": -10,
-                            "internalChannelModifier": -10,
-                            "quantity": 1,
-                            "sourceTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "internalTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            },
-                            "userSpecifiedCurrencyTotal": {
-                              "amount": 1250,
-                              "currency": "USD"
-                            }
-                          },
-                          "startDate": "2017-12-22T03:07:58.742+0000",
-                          "endDate": "2017-12-22T08:07:58.742+0000",
-                          "attendees": 2,
-                          "imageIdentifier": "cloudinary-image-1",
-                          "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                          "localizedName": "Plass 1",
-                          "localizedDescription": "place-1",
-                          "contact": {
-                            "firstName": "Alexandra",
-                            "lastName": "Beaumont",
-                            "email": "johnsmith@email.com",
-                            "secondaryEmail": "johnsmith2@email.com",
-                            "phoneNumber": "+12125551212",
-                            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                            "fullName": "Alexandra Beaumont"
-                          },
-                          "address": {
-                            "address1": "234 Near da beach",
-                            "address2": "Pebble #5001",
-                            "state": "CA",
-                            "postalCode": "90210",
-                            "county": "Alameda county",
-                            "city": "Bangkok",
-                            "countryCode": "TH",
-                            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                            "country": "United States"
-                          },
-                          "financialBreakdown": {
-                            "displayPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "internalPriceQuote": {
-                              "source": "USD",
-                              "target": "THB",
-                              "exchangeRate": 33.5,
-                              "timestamp": 1705233000000
-                            },
-                            "beneficiaryList": [
-                              {
-                                "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                                "accountName": "The Siam Residences, Bangkok",
-                                "accountEmail": "reservations@thesiamresidences.com",
-                                "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                                "amountDue": {
-                                  "percent": 0.05
-                                },
-                                "sourceCurrency": "THB",
-                                "displayCurrency": "USD",
-                                "internalCurrency": "USD",
-                                "sourceAmount": 450,
-                                "displayAmount": 450,
-                                "internalAmount": 450,
-                                "sourceAmountRefundModifier": 45,
-                                "displayAmountRefundModifier": 45,
-                                "internalAmountRefundModifier": 45,
-                                "pendingRefunds": [
-                                  {
-                                    "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                                    "sourceAmountRefundModifier": 45,
-                                    "displayAmountRefundModifier": 45,
-                                    "internalAmountRefundModifier": 45
-                                  }
-                                ],
-                                "netSourceAmount": 450,
-                                "netDisplayAmount": 450,
-                                "netInternalAmount": 450,
-                                "reconciled": false
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "totalPaymentProcessingFeeSourceAmount": {
-                        "amount": 1250,
-                        "currency": "USD"
-                      },
                       "netTotalSalesSourceAmountOrZero": {
                         "amount": 1250,
                         "currency": "USD"
@@ -28297,6 +28261,10 @@
                         "currency": "USD"
                       },
                       "totalPlatformFeeSourceAmount": {
+                        "amount": 1250,
+                        "currency": "USD"
+                      },
+                      "totalPaymentProcessingFeeSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
                       },
@@ -28311,7 +28279,39 @@
                       "totalSupplierAgencyFeesSourceAmount": {
                         "amount": 1250,
                         "currency": "USD"
-                      }
+                      },
+                      "beneficiaryList": [
+                        {
+                          "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                          "accountName": "The Siam Residences, Bangkok",
+                          "accountEmail": "reservations@thesiamresidences.com",
+                          "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                          "amountDue": {
+                            "percent": 0.05
+                          },
+                          "sourceCurrency": "THB",
+                          "displayCurrency": "USD",
+                          "internalCurrency": "USD",
+                          "sourceAmount": 450,
+                          "displayAmount": 450,
+                          "internalAmount": 450,
+                          "sourceAmountRefundModifier": 45,
+                          "displayAmountRefundModifier": 45,
+                          "internalAmountRefundModifier": 45,
+                          "pendingRefunds": [
+                            {
+                              "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                              "sourceAmountRefundModifier": 45,
+                              "displayAmountRefundModifier": 45,
+                              "internalAmountRefundModifier": 45
+                            }
+                          ],
+                          "netSourceAmount": 450,
+                          "netDisplayAmount": 450,
+                          "netInternalAmount": 450,
+                          "reconciled": false
+                        }
+                      ]
                     }
                   ],
                   "number": 0,
@@ -29322,8 +29322,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -29359,18 +29359,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -29398,8 +29398,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -29895,8 +29895,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -29987,8 +29987,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -32212,8 +32212,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -32223,8 +32223,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "financialBreakdown": {
             "displayPriceQuote": {
@@ -32645,18 +32645,6 @@
               "default": ""
             }
           },
-          "guests": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total guests for this stay"
-          },
-          "rooms": {
-            "type": "integer",
-            "format": "int32",
-            "default": "",
-            "description": "How many total rooms for this stay"
-          },
           "hours": {
             "type": "integer",
             "format": "int64",
@@ -32669,6 +32657,18 @@
             "format": "int32",
             "default": "",
             "description": "How many total children for this stay"
+          },
+          "guests": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total guests for this stay"
+          },
+          "rooms": {
+            "type": "integer",
+            "format": "int32",
+            "default": "",
+            "description": "How many total rooms for this stay"
           }
         },
         "required": [
@@ -32826,8 +32826,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -32837,8 +32837,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "commissionable": true,
               "name": "Archery lesson",
@@ -33245,8 +33245,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 },
                 "address": {
                   "address1": "234 Near da beach",
@@ -33256,8 +33256,8 @@
                   "county": "Alameda county",
                   "city": "Bangkok",
                   "countryCode": "TH",
-                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                  "country": "United States"
+                  "country": "United States",
+                  "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                 },
                 "financialBreakdown": {
                   "displayPriceQuote": {
@@ -33397,8 +33397,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     }
                   ],
                   "petInfo": [
@@ -33858,6 +33858,208 @@
               "currency": "USD"
             }
           ],
+          "guestUser": {
+            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+            "firstName": "Alexandra",
+            "lastName": "Beaumont",
+            "email": "reservations@thesiamresidences.com",
+            "telephone": "+1 212 555 1212",
+            "profile": {
+              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+              "createdDate": "2026-01-14T09:30:00",
+              "lastUpdate": "2026-02-03T16:45:12",
+              "version": 3,
+              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+              "share": true,
+              "user": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "alexandra@beaumont.com",
+                "phone": "+66212658866",
+                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                "fullName": "Alexandra Beaumont"
+              },
+              "personal": {
+                "gender": "FEMALE",
+                "birthDate": "1985-06-15",
+                "maritalStatus": "MARRIED",
+                "childQuantity": 2,
+                "citizenship": "Thailand",
+                "address1": "123 Petchburi Road",
+                "address2": "Ratchathewi District",
+                "city": "Bangkok",
+                "state": "Bangkok",
+                "postalCode": "10400",
+                "country": "TH",
+                "preferredCurrency": "USD",
+                "language": "en",
+                "contactPerson": [
+                  {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  }
+                ],
+                "petInfo": [
+                  {
+                    "name": "Luna",
+                    "type": "Golden Retriever"
+                  }
+                ]
+              },
+              "preferences": {
+                "propertyLocationPref": "Beachfront",
+                "propertyTypePref": "Luxury Resort",
+                "hotelChainPref": "Mandarin Oriental",
+                "physChalFeaturePref": "Wheelchair accessible rooms",
+                "smokingAllowed": false,
+                "roomLocationPref": "High floor with city view",
+                "bedTypePref": "King bed",
+                "foodSrvcPref": "In-room dining",
+                "guestType": "Business traveler",
+                "mealPref": "Continental breakfast",
+                "cuisinePref": "Thai"
+              }
+            },
+            "fullName": "Alexandra Beaumont"
+          },
+          "ancillaryList": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
           "meetingRooms": [
             {
               "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -33928,8 +34130,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -33939,8 +34141,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -34060,8 +34262,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34071,8 +34273,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -34192,8 +34394,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34203,8 +34405,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -34324,8 +34526,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34335,8 +34537,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -34456,8 +34658,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34467,8 +34669,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -34588,8 +34790,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34599,8 +34801,140 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+              },
+              "financialBreakdown": {
+                "displayPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "internalPriceQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "beneficiaryList": [
+                  {
+                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                    "accountName": "The Siam Residences, Bangkok",
+                    "accountEmail": "reservations@thesiamresidences.com",
+                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                    "amountDue": {
+                      "percent": 0.05
+                    },
+                    "sourceCurrency": "THB",
+                    "displayCurrency": "USD",
+                    "internalCurrency": "USD",
+                    "sourceAmount": 450,
+                    "displayAmount": 450,
+                    "internalAmount": 450,
+                    "sourceAmountRefundModifier": 45,
+                    "displayAmountRefundModifier": 45,
+                    "internalAmountRefundModifier": 45,
+                    "pendingRefunds": [
+                      {
+                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45
+                      }
+                    ],
+                    "netSourceAmount": 450,
+                    "netDisplayAmount": 450,
+                    "netInternalAmount": 450,
+                    "reconciled": false
+                  }
+                ]
+              }
+            }
+          ],
+          "roomTypeAncillaries": [
+            {
+              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+              "name": "Thai Massage Spa Treatment",
+              "pricingType": "PER_USE",
+              "type": "ADD_ON",
+              "price": {
+                "sourceToUserCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "sourceToInternalCurrencyQuote": {
+                  "source": "USD",
+                  "target": "THB",
+                  "exchangeRate": 33.5,
+                  "timestamp": 1705233000000
+                },
+                "userSpecifiedCurrencyBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "sourceBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalBaseTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyPromotionalModifier": -40,
+                "sourcePromotionalModifier": -40,
+                "internalPromotionalModifier": -40,
+                "userSpecifiedCurrencyPremiumModifier": 40,
+                "sourcePremiumModifier": 40,
+                "internalPremiumModifier": 40,
+                "userSpecifiedCurrencyChannelModifier": -10,
+                "sourceChannelModifier": -10,
+                "internalChannelModifier": -10,
+                "quantity": 1,
+                "sourceTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "internalTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                },
+                "userSpecifiedCurrencyTotal": {
+                  "amount": 1250,
+                  "currency": "USD"
+                }
+              },
+              "startDate": "2017-12-22T03:07:58.742+0000",
+              "endDate": "2017-12-22T08:07:58.742+0000",
+              "attendees": 2,
+              "imageIdentifier": "cloudinary-image-1",
+              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+              "localizedName": "Plass 1",
+              "localizedDescription": "place-1",
+              "contact": {
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "johnsmith@email.com",
+                "secondaryEmail": "johnsmith2@email.com",
+                "phoneNumber": "+12125551212",
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+              },
+              "address": {
+                "address1": "234 Near da beach",
+                "address2": "Pebble #5001",
+                "state": "CA",
+                "postalCode": "90210",
+                "county": "Alameda county",
+                "city": "Bangkok",
+                "countryCode": "TH",
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -34720,8 +35054,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -34731,242 +35065,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "beneficiaryList": [
-            {
-              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-              "accountName": "The Siam Residences, Bangkok",
-              "accountEmail": "reservations@thesiamresidences.com",
-              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-              "amountDue": {
-                "percent": 0.05
-              },
-              "sourceCurrency": "THB",
-              "displayCurrency": "USD",
-              "internalCurrency": "USD",
-              "sourceAmount": 450,
-              "displayAmount": 450,
-              "internalAmount": 450,
-              "sourceAmountRefundModifier": 45,
-              "displayAmountRefundModifier": 45,
-              "internalAmountRefundModifier": 45,
-              "pendingRefunds": [
-                {
-                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45
-                }
-              ],
-              "netSourceAmount": 450,
-              "netDisplayAmount": 450,
-              "netInternalAmount": 450,
-              "reconciled": false
-            }
-          ],
-          "guestUser": {
-            "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-            "firstName": "Alexandra",
-            "lastName": "Beaumont",
-            "email": "reservations@thesiamresidences.com",
-            "telephone": "+1 212 555 1212",
-            "profile": {
-              "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-              "createdDate": "2026-01-14T09:30:00",
-              "lastUpdate": "2026-02-03T16:45:12",
-              "version": 3,
-              "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-              "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-              "share": true,
-              "user": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "alexandra@beaumont.com",
-                "phone": "+66212658866",
-                "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                "fullName": "Alexandra Beaumont"
-              },
-              "personal": {
-                "gender": "FEMALE",
-                "birthDate": "1985-06-15",
-                "maritalStatus": "MARRIED",
-                "childQuantity": 2,
-                "citizenship": "Thailand",
-                "address1": "123 Petchburi Road",
-                "address2": "Ratchathewi District",
-                "city": "Bangkok",
-                "state": "Bangkok",
-                "postalCode": "10400",
-                "country": "TH",
-                "preferredCurrency": "USD",
-                "language": "en",
-                "contactPerson": [
-                  {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  }
-                ],
-                "petInfo": [
-                  {
-                    "name": "Luna",
-                    "type": "Golden Retriever"
-                  }
-                ]
-              },
-              "preferences": {
-                "propertyLocationPref": "Beachfront",
-                "propertyTypePref": "Luxury Resort",
-                "hotelChainPref": "Mandarin Oriental",
-                "physChalFeaturePref": "Wheelchair accessible rooms",
-                "smokingAllowed": false,
-                "roomLocationPref": "High floor with city view",
-                "bedTypePref": "King bed",
-                "foodSrvcPref": "In-room dining",
-                "guestType": "Business traveler",
-                "mealPref": "Continental breakfast",
-                "cuisinePref": "Thai"
-              }
-            },
-            "fullName": "Alexandra Beaumont"
-          },
-          "ancillaryList": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -35017,142 +35117,6 @@
             }
           ],
           "cancellable": false,
-          "roomTypeAncillaries": [
-            {
-              "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-              "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-              "name": "Thai Massage Spa Treatment",
-              "pricingType": "PER_USE",
-              "type": "ADD_ON",
-              "price": {
-                "sourceToUserCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "sourceToInternalCurrencyQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "userSpecifiedCurrencyBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "sourceBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalBaseTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyPromotionalModifier": -40,
-                "sourcePromotionalModifier": -40,
-                "internalPromotionalModifier": -40,
-                "userSpecifiedCurrencyPremiumModifier": 40,
-                "sourcePremiumModifier": 40,
-                "internalPremiumModifier": 40,
-                "userSpecifiedCurrencyChannelModifier": -10,
-                "sourceChannelModifier": -10,
-                "internalChannelModifier": -10,
-                "quantity": 1,
-                "sourceTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "internalTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                },
-                "userSpecifiedCurrencyTotal": {
-                  "amount": 1250,
-                  "currency": "USD"
-                }
-              },
-              "startDate": "2017-12-22T03:07:58.742+0000",
-              "endDate": "2017-12-22T08:07:58.742+0000",
-              "attendees": 2,
-              "imageIdentifier": "cloudinary-image-1",
-              "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-              "localizedName": "Plass 1",
-              "localizedDescription": "place-1",
-              "contact": {
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "johnsmith@email.com",
-                "secondaryEmail": "johnsmith2@email.com",
-                "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
-              },
-              "address": {
-                "address1": "234 Near da beach",
-                "address2": "Pebble #5001",
-                "state": "CA",
-                "postalCode": "90210",
-                "county": "Alameda county",
-                "city": "Bangkok",
-                "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
-              },
-              "financialBreakdown": {
-                "displayPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "internalPriceQuote": {
-                  "source": "USD",
-                  "target": "THB",
-                  "exchangeRate": 33.5,
-                  "timestamp": 1705233000000
-                },
-                "beneficiaryList": [
-                  {
-                    "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                    "accountName": "The Siam Residences, Bangkok",
-                    "accountEmail": "reservations@thesiamresidences.com",
-                    "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                    "amountDue": {
-                      "percent": 0.05
-                    },
-                    "sourceCurrency": "THB",
-                    "displayCurrency": "USD",
-                    "internalCurrency": "USD",
-                    "sourceAmount": 450,
-                    "displayAmount": 450,
-                    "internalAmount": 450,
-                    "sourceAmountRefundModifier": 45,
-                    "displayAmountRefundModifier": 45,
-                    "internalAmountRefundModifier": 45,
-                    "pendingRefunds": [
-                      {
-                        "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45
-                      }
-                    ],
-                    "netSourceAmount": 450,
-                    "netDisplayAmount": 450,
-                    "netInternalAmount": 450,
-                    "reconciled": false
-                  }
-                ]
-              }
-            }
-          ],
-          "totalPaymentProcessingFeeSourceAmount": {
-            "amount": 1250,
-            "currency": "USD"
-          },
           "netTotalSalesSourceAmountOrZero": {
             "amount": 1250,
             "currency": "USD"
@@ -35162,6 +35126,10 @@
             "currency": "USD"
           },
           "totalPlatformFeeSourceAmount": {
+            "amount": 1250,
+            "currency": "USD"
+          },
+          "totalPaymentProcessingFeeSourceAmount": {
             "amount": 1250,
             "currency": "USD"
           },
@@ -35176,7 +35144,39 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "amount": 1250,
             "currency": "USD"
-          }
+          },
+          "beneficiaryList": [
+            {
+              "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+              "accountName": "The Siam Residences, Bangkok",
+              "accountEmail": "reservations@thesiamresidences.com",
+              "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+              "amountDue": {
+                "percent": 0.05
+              },
+              "sourceCurrency": "THB",
+              "displayCurrency": "USD",
+              "internalCurrency": "USD",
+              "sourceAmount": 450,
+              "displayAmount": 450,
+              "internalAmount": 450,
+              "sourceAmountRefundModifier": 45,
+              "displayAmountRefundModifier": 45,
+              "internalAmountRefundModifier": 45,
+              "pendingRefunds": [
+                {
+                  "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45
+                }
+              ],
+              "netSourceAmount": 450,
+              "netDisplayAmount": 450,
+              "netInternalAmount": 450,
+              "reconciled": false
+            }
+          ]
         },
         "properties": {
           "id": {
@@ -35586,6 +35586,28 @@
               "default": ""
             }
           },
+          "cancelled": {
+            "type": "boolean"
+          },
+          "rateSource": {
+            "type": "string"
+          },
+          "cancelledOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "guestUser": {
+            "$ref": "#/components/schemas/GuestUser_Booker"
+          },
+          "cancelReason": {
+            "type": "string"
+          },
+          "ancillaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_Booker"
+            }
+          },
           "meetingRooms": {
             "type": "array",
             "items": {
@@ -35622,38 +35644,50 @@
               "$ref": "#/components/schemas/BookingAncillary_Booker"
             }
           },
+          "roomTypeAncillaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BookingAncillary_Booker"
+            }
+          },
           "addOns": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BookingAncillary_Booker"
             }
           },
-          "rateSource": {
+          "cancellationType": {
+            "type": "string",
+            "description": "Reason category for a booking cancellation",
+            "enum": [
+              "DUPLICATE",
+              "CANCELLATION",
+              "NO_SHOW",
+              "CC_INVALID",
+              "CC_INSUFFICIENT",
+              "DISCRETIONARY"
+            ],
+            "default": null
+          },
+          "cancellable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
+          },
+          "displayCurrency": {
             "type": "string"
-          },
-          "beneficiaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Beneficiary_Booker"
-            }
-          },
-          "agentPayment": {
-            "type": "boolean"
-          },
-          "guestUser": {
-            "$ref": "#/components/schemas/GuestUser_Booker"
-          },
-          "ancillaryList": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_Booker"
-            }
-          },
-          "agentSelfManaged": {
-            "type": "boolean"
           },
           "roomImageUrl": {
             "type": "string"
+          },
+          "netDisplayAmount": {
+            "type": "number"
+          },
+          "netTotalSalesSourceAmountOrZero": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
+          "netSourceAmountOrZero": {
+            "type": "number"
           },
           "hasRefunds": {
             "type": "boolean"
@@ -35669,55 +35703,6 @@
             ],
             "default": null
           },
-          "cancelledOn": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cancellable": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether the booking can still be voluntarily cancelled (no later than the arrival day)."
-          },
-          "displayCurrency": {
-            "type": "string"
-          },
-          "cancelReason": {
-            "type": "string"
-          },
-          "cancellationType": {
-            "type": "string",
-            "description": "Reason category for a booking cancellation",
-            "enum": [
-              "DUPLICATE",
-              "CANCELLATION",
-              "NO_SHOW",
-              "CC_INVALID",
-              "CC_INSUFFICIENT",
-              "DISCRETIONARY"
-            ],
-            "default": null
-          },
-          "paymentTransactionIdentifier": {
-            "type": "string"
-          },
-          "roomTypeAncillaries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BookingAncillary_Booker"
-            }
-          },
-          "totalPaymentProcessingFeeSourceAmount": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netDisplayAmount": {
-            "type": "number"
-          },
-          "netTotalSalesSourceAmountOrZero": {
-            "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "netSourceAmountOrZero": {
-            "type": "number"
-          },
           "bookingContractIdentifier": {
             "type": "string"
           },
@@ -35730,6 +35715,9 @@
           "totalPlatformFeeSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
+          "totalPaymentProcessingFeeSourceAmount": {
+            "$ref": "#/components/schemas/CustomMonetaryAmount"
+          },
           "commissionableSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
@@ -35739,8 +35727,20 @@
           "totalSupplierAgencyFeesSourceAmount": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
           },
-          "cancelled": {
+          "agentPayment": {
             "type": "boolean"
+          },
+          "agentSelfManaged": {
+            "type": "boolean"
+          },
+          "beneficiaryList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beneficiary_Booker"
+            }
+          },
+          "paymentTransactionIdentifier": {
+            "type": "string"
           }
         }
       },
@@ -36185,8 +36185,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             },
             "address": {
               "address1": "234 Near da beach",
@@ -36196,8 +36196,8 @@
               "county": "Alameda county",
               "city": "Bangkok",
               "countryCode": "TH",
-              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-              "country": "United States"
+              "country": "United States",
+              "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
             },
             "commissionable": true,
             "name": "Archery lesson",
@@ -36604,8 +36604,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               },
               "address": {
                 "address1": "234 Near da beach",
@@ -36615,8 +36615,8 @@
                 "county": "Alameda county",
                 "city": "Bangkok",
                 "countryCode": "TH",
-                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                "country": "United States"
+                "country": "United States",
+                "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
               },
               "financialBreakdown": {
                 "displayPriceQuote": {
@@ -36756,8 +36756,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   }
                 ],
                 "petInfo": [
@@ -36914,16 +36914,16 @@
             "description": "Check-out date",
             "example": "2025-12-27"
           },
-          "roomNights": {
+          "guests": {
             "type": "integer",
-            "format": "int64"
+            "format": "int32"
           },
           "rateSource": {
             "type": "string"
           },
-          "guests": {
+          "roomNights": {
             "type": "integer",
-            "format": "int32"
+            "format": "int64"
           },
           "sourceTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
@@ -37629,8 +37629,8 @@
           "email": "johnsmith@email.com",
           "secondaryEmail": "johnsmith2@email.com",
           "phoneNumber": "+12125551212",
-          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-          "fullName": "Alexandra Beaumont"
+          "fullName": "Alexandra Beaumont",
+          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
         },
         "properties": {
           "firstName": {
@@ -37666,18 +37666,18 @@
             "example": "+12125551212",
             "pattern": "^\\+?[1-9]\\d{1,14}$"
           },
-          "summary": {
-            "type": "string",
-            "default": "",
-            "description": "Summary",
-            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "readOnly": true
-          },
           "fullName": {
             "type": "string",
             "default": "",
             "description": "First and last name",
             "example": "Alexandra Beaumont",
+            "readOnly": true
+          },
+          "summary": {
+            "type": "string",
+            "default": "",
+            "description": "Summary",
+            "example": "John Smith (johnsmith@gmail.com / +12125551212)",
             "readOnly": true
           }
         }
@@ -39081,15 +39081,15 @@
             "type": "number",
             "format": "double"
           },
+          "type": {
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
             }
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -39319,8 +39319,8 @@
             "email": "johnsmith@email.com",
             "secondaryEmail": "johnsmith2@email.com",
             "phoneNumber": "+12125551212",
-            "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-            "fullName": "Alexandra Beaumont"
+            "fullName": "Alexandra Beaumont",
+            "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
           },
           "address": {
             "address1": "234 Near da beach",
@@ -39330,8 +39330,8 @@
             "county": "Alameda county",
             "city": "Bangkok",
             "countryCode": "TH",
-            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "country": "United States"
+            "country": "United States",
+            "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
           },
           "commissionable": true,
           "name": "Archery lesson",
@@ -39959,8 +39959,8 @@
                   "email": "johnsmith@email.com",
                   "secondaryEmail": "johnsmith2@email.com",
                   "phoneNumber": "+12125551212",
-                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                  "fullName": "Alexandra Beaumont"
+                  "fullName": "Alexandra Beaumont",
+                  "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                 }
               ],
               "petInfo": [
@@ -40227,6 +40227,9 @@
             "default": "",
             "description": "Premium percent"
           },
+          "totalDiscountPercent": {
+            "type": "number"
+          },
           "hasChannelDiscount": {
             "type": "boolean"
           },
@@ -40244,9 +40247,6 @@
           },
           "userSpecifiedCurrencyTotal": {
             "$ref": "#/components/schemas/CustomMonetaryAmount"
-          },
-          "totalDiscountPercent": {
-            "type": "number"
           }
         },
         "required": [
@@ -40436,8 +40436,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -40447,8 +40447,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "commissionable": true,
                   "name": "Archery lesson",
@@ -40855,8 +40855,8 @@
                       "email": "johnsmith@email.com",
                       "secondaryEmail": "johnsmith2@email.com",
                       "phoneNumber": "+12125551212",
-                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                      "fullName": "Alexandra Beaumont"
+                      "fullName": "Alexandra Beaumont",
+                      "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                     },
                     "address": {
                       "address1": "234 Near da beach",
@@ -40866,8 +40866,8 @@
                       "county": "Alameda county",
                       "city": "Bangkok",
                       "countryCode": "TH",
-                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                      "country": "United States"
+                      "country": "United States",
+                      "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                     },
                     "financialBreakdown": {
                       "displayPriceQuote": {
@@ -41007,8 +41007,8 @@
                           "email": "johnsmith@email.com",
                           "secondaryEmail": "johnsmith2@email.com",
                           "phoneNumber": "+12125551212",
-                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                          "fullName": "Alexandra Beaumont"
+                          "fullName": "Alexandra Beaumont",
+                          "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                         }
                       ],
                       "petInfo": [
@@ -41468,6 +41468,208 @@
                   "currency": "USD"
                 }
               ],
+              "guestUser": {
+                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                "firstName": "Alexandra",
+                "lastName": "Beaumont",
+                "email": "reservations@thesiamresidences.com",
+                "telephone": "+1 212 555 1212",
+                "profile": {
+                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
+                  "createdDate": "2026-01-14T09:30:00",
+                  "lastUpdate": "2026-02-03T16:45:12",
+                  "version": 3,
+                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
+                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
+                  "share": true,
+                  "user": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "alexandra@beaumont.com",
+                    "phone": "+66212658866",
+                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
+                    "fullName": "Alexandra Beaumont"
+                  },
+                  "personal": {
+                    "gender": "FEMALE",
+                    "birthDate": "1985-06-15",
+                    "maritalStatus": "MARRIED",
+                    "childQuantity": 2,
+                    "citizenship": "Thailand",
+                    "address1": "123 Petchburi Road",
+                    "address2": "Ratchathewi District",
+                    "city": "Bangkok",
+                    "state": "Bangkok",
+                    "postalCode": "10400",
+                    "country": "TH",
+                    "preferredCurrency": "USD",
+                    "language": "en",
+                    "contactPerson": [
+                      {
+                        "firstName": "Alexandra",
+                        "lastName": "Beaumont",
+                        "email": "johnsmith@email.com",
+                        "secondaryEmail": "johnsmith2@email.com",
+                        "phoneNumber": "+12125551212",
+                        "fullName": "Alexandra Beaumont",
+                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                      }
+                    ],
+                    "petInfo": [
+                      {
+                        "name": "Luna",
+                        "type": "Golden Retriever"
+                      }
+                    ]
+                  },
+                  "preferences": {
+                    "propertyLocationPref": "Beachfront",
+                    "propertyTypePref": "Luxury Resort",
+                    "hotelChainPref": "Mandarin Oriental",
+                    "physChalFeaturePref": "Wheelchair accessible rooms",
+                    "smokingAllowed": false,
+                    "roomLocationPref": "High floor with city view",
+                    "bedTypePref": "King bed",
+                    "foodSrvcPref": "In-room dining",
+                    "guestType": "Business traveler",
+                    "mealPref": "Continental breakfast",
+                    "cuisinePref": "Thai"
+                  }
+                },
+                "fullName": "Alexandra Beaumont"
+              },
+              "ancillaryList": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
               "meetingRooms": [
                 {
                   "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
@@ -41538,8 +41740,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -41549,8 +41751,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -41670,8 +41872,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -41681,8 +41883,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -41802,8 +42004,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -41813,8 +42015,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -41934,8 +42136,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -41945,8 +42147,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -42066,8 +42268,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -42077,8 +42279,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -42198,8 +42400,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -42209,8 +42411,140 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
+                  },
+                  "financialBreakdown": {
+                    "displayPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "internalPriceQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "beneficiaryList": [
+                      {
+                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                        "accountName": "The Siam Residences, Bangkok",
+                        "accountEmail": "reservations@thesiamresidences.com",
+                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                        "amountDue": {
+                          "percent": 0.05
+                        },
+                        "sourceCurrency": "THB",
+                        "displayCurrency": "USD",
+                        "internalCurrency": "USD",
+                        "sourceAmount": 450,
+                        "displayAmount": 450,
+                        "internalAmount": 450,
+                        "sourceAmountRefundModifier": 45,
+                        "displayAmountRefundModifier": 45,
+                        "internalAmountRefundModifier": 45,
+                        "pendingRefunds": [
+                          {
+                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                            "sourceAmountRefundModifier": 45,
+                            "displayAmountRefundModifier": 45,
+                            "internalAmountRefundModifier": 45
+                          }
+                        ],
+                        "netSourceAmount": 450,
+                        "netDisplayAmount": 450,
+                        "netInternalAmount": 450,
+                        "reconciled": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "roomTypeAncillaries": [
+                {
+                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
+                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
+                  "name": "Thai Massage Spa Treatment",
+                  "pricingType": "PER_USE",
+                  "type": "ADD_ON",
+                  "price": {
+                    "sourceToUserCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "sourceToInternalCurrencyQuote": {
+                      "source": "USD",
+                      "target": "THB",
+                      "exchangeRate": 33.5,
+                      "timestamp": 1705233000000
+                    },
+                    "userSpecifiedCurrencyBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "sourceBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalBaseTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyPromotionalModifier": -40,
+                    "sourcePromotionalModifier": -40,
+                    "internalPromotionalModifier": -40,
+                    "userSpecifiedCurrencyPremiumModifier": 40,
+                    "sourcePremiumModifier": 40,
+                    "internalPremiumModifier": 40,
+                    "userSpecifiedCurrencyChannelModifier": -10,
+                    "sourceChannelModifier": -10,
+                    "internalChannelModifier": -10,
+                    "quantity": 1,
+                    "sourceTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "internalTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    },
+                    "userSpecifiedCurrencyTotal": {
+                      "amount": 1250,
+                      "currency": "USD"
+                    }
+                  },
+                  "startDate": "2017-12-22T03:07:58.742+0000",
+                  "endDate": "2017-12-22T08:07:58.742+0000",
+                  "attendees": 2,
+                  "imageIdentifier": "cloudinary-image-1",
+                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
+                  "localizedName": "Plass 1",
+                  "localizedDescription": "place-1",
+                  "contact": {
+                    "firstName": "Alexandra",
+                    "lastName": "Beaumont",
+                    "email": "johnsmith@email.com",
+                    "secondaryEmail": "johnsmith2@email.com",
+                    "phoneNumber": "+12125551212",
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
+                  },
+                  "address": {
+                    "address1": "234 Near da beach",
+                    "address2": "Pebble #5001",
+                    "state": "CA",
+                    "postalCode": "90210",
+                    "county": "Alameda county",
+                    "city": "Bangkok",
+                    "countryCode": "TH",
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -42330,8 +42664,8 @@
                     "email": "johnsmith@email.com",
                     "secondaryEmail": "johnsmith2@email.com",
                     "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
+                    "fullName": "Alexandra Beaumont",
+                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
                   },
                   "address": {
                     "address1": "234 Near da beach",
@@ -42341,242 +42675,8 @@
                     "county": "Alameda county",
                     "city": "Bangkok",
                     "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "beneficiaryList": [
-                {
-                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                  "accountName": "The Siam Residences, Bangkok",
-                  "accountEmail": "reservations@thesiamresidences.com",
-                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                  "amountDue": {
-                    "percent": 0.05
-                  },
-                  "sourceCurrency": "THB",
-                  "displayCurrency": "USD",
-                  "internalCurrency": "USD",
-                  "sourceAmount": 450,
-                  "displayAmount": 450,
-                  "internalAmount": 450,
-                  "sourceAmountRefundModifier": 45,
-                  "displayAmountRefundModifier": 45,
-                  "internalAmountRefundModifier": 45,
-                  "pendingRefunds": [
-                    {
-                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                      "sourceAmountRefundModifier": 45,
-                      "displayAmountRefundModifier": 45,
-                      "internalAmountRefundModifier": 45
-                    }
-                  ],
-                  "netSourceAmount": 450,
-                  "netDisplayAmount": 450,
-                  "netInternalAmount": 450,
-                  "reconciled": false
-                }
-              ],
-              "guestUser": {
-                "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                "firstName": "Alexandra",
-                "lastName": "Beaumont",
-                "email": "reservations@thesiamresidences.com",
-                "telephone": "+1 212 555 1212",
-                "profile": {
-                  "id": "b7e4c1a2-3f5d-4e8a-9c21-6f0b5d8e3a47",
-                  "createdDate": "2026-01-14T09:30:00",
-                  "lastUpdate": "2026-02-03T16:45:12",
-                  "version": 3,
-                  "profileIdentifier": "3c6b1a5d-8e2f-4a0b-9c7d-6e4f0a8b2c51",
-                  "userIdentifier": "c3a9f2e1-8b4d-4c7a-a1e2-5f0b6d9e2c84",
-                  "share": true,
-                  "user": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "alexandra@beaumont.com",
-                    "phone": "+66212658866",
-                    "profilePictureUrl": "https://res.cloudinary.com/wink/image/upload/v1/user/alexandra-beaumont.jpg",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "personal": {
-                    "gender": "FEMALE",
-                    "birthDate": "1985-06-15",
-                    "maritalStatus": "MARRIED",
-                    "childQuantity": 2,
-                    "citizenship": "Thailand",
-                    "address1": "123 Petchburi Road",
-                    "address2": "Ratchathewi District",
-                    "city": "Bangkok",
-                    "state": "Bangkok",
-                    "postalCode": "10400",
-                    "country": "TH",
-                    "preferredCurrency": "USD",
-                    "language": "en",
-                    "contactPerson": [
-                      {
-                        "firstName": "Alexandra",
-                        "lastName": "Beaumont",
-                        "email": "johnsmith@email.com",
-                        "secondaryEmail": "johnsmith2@email.com",
-                        "phoneNumber": "+12125551212",
-                        "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                        "fullName": "Alexandra Beaumont"
-                      }
-                    ],
-                    "petInfo": [
-                      {
-                        "name": "Luna",
-                        "type": "Golden Retriever"
-                      }
-                    ]
-                  },
-                  "preferences": {
-                    "propertyLocationPref": "Beachfront",
-                    "propertyTypePref": "Luxury Resort",
-                    "hotelChainPref": "Mandarin Oriental",
-                    "physChalFeaturePref": "Wheelchair accessible rooms",
-                    "smokingAllowed": false,
-                    "roomLocationPref": "High floor with city view",
-                    "bedTypePref": "King bed",
-                    "foodSrvcPref": "In-room dining",
-                    "guestType": "Business traveler",
-                    "mealPref": "Continental breakfast",
-                    "cuisinePref": "Thai"
-                  }
-                },
-                "fullName": "Alexandra Beaumont"
-              },
-              "ancillaryList": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
+                    "country": "United States",
+                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
                   },
                   "financialBreakdown": {
                     "displayPriceQuote": {
@@ -42627,142 +42727,6 @@
                 }
               ],
               "cancellable": false,
-              "roomTypeAncillaries": [
-                {
-                  "identifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "hotelIdentifier": "e2c7b4d3-1a8f-4e9c-b5d6-3a9f0e7c2b18",
-                  "typeIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "transactionalTravelInventoryIdentifier": "8b1d6e0f-3a7c-4d2b-9e5a-1c8f0b4d6e29",
-                  "name": "Thai Massage Spa Treatment",
-                  "pricingType": "PER_USE",
-                  "type": "ADD_ON",
-                  "price": {
-                    "sourceToUserCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "sourceToInternalCurrencyQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "userSpecifiedCurrencyBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "sourceBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalBaseTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyPromotionalModifier": -40,
-                    "sourcePromotionalModifier": -40,
-                    "internalPromotionalModifier": -40,
-                    "userSpecifiedCurrencyPremiumModifier": 40,
-                    "sourcePremiumModifier": 40,
-                    "internalPremiumModifier": 40,
-                    "userSpecifiedCurrencyChannelModifier": -10,
-                    "sourceChannelModifier": -10,
-                    "internalChannelModifier": -10,
-                    "quantity": 1,
-                    "sourceTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "internalTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    },
-                    "userSpecifiedCurrencyTotal": {
-                      "amount": 1250,
-                      "currency": "USD"
-                    }
-                  },
-                  "startDate": "2017-12-22T03:07:58.742+0000",
-                  "endDate": "2017-12-22T08:07:58.742+0000",
-                  "attendees": 2,
-                  "imageIdentifier": "cloudinary-image-1",
-                  "imageUrl": "https://path.to.image.com/this-is-me.jpg",
-                  "localizedName": "Plass 1",
-                  "localizedDescription": "place-1",
-                  "contact": {
-                    "firstName": "Alexandra",
-                    "lastName": "Beaumont",
-                    "email": "johnsmith@email.com",
-                    "secondaryEmail": "johnsmith2@email.com",
-                    "phoneNumber": "+12125551212",
-                    "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                    "fullName": "Alexandra Beaumont"
-                  },
-                  "address": {
-                    "address1": "234 Near da beach",
-                    "address2": "Pebble #5001",
-                    "state": "CA",
-                    "postalCode": "90210",
-                    "county": "Alameda county",
-                    "city": "Bangkok",
-                    "countryCode": "TH",
-                    "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-                    "country": "United States"
-                  },
-                  "financialBreakdown": {
-                    "displayPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "internalPriceQuote": {
-                      "source": "USD",
-                      "target": "THB",
-                      "exchangeRate": 33.5,
-                      "timestamp": 1705233000000
-                    },
-                    "beneficiaryList": [
-                      {
-                        "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
-                        "accountName": "The Siam Residences, Bangkok",
-                        "accountEmail": "reservations@thesiamresidences.com",
-                        "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
-                        "amountDue": {
-                          "percent": 0.05
-                        },
-                        "sourceCurrency": "THB",
-                        "displayCurrency": "USD",
-                        "internalCurrency": "USD",
-                        "sourceAmount": 450,
-                        "displayAmount": 450,
-                        "internalAmount": 450,
-                        "sourceAmountRefundModifier": 45,
-                        "displayAmountRefundModifier": 45,
-                        "internalAmountRefundModifier": 45,
-                        "pendingRefunds": [
-                          {
-                            "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
-                            "sourceAmountRefundModifier": 45,
-                            "displayAmountRefundModifier": 45,
-                            "internalAmountRefundModifier": 45
-                          }
-                        ],
-                        "netSourceAmount": 450,
-                        "netDisplayAmount": 450,
-                        "netInternalAmount": 450,
-                        "reconciled": false
-                      }
-                    ]
-                  }
-                }
-              ],
-              "totalPaymentProcessingFeeSourceAmount": {
-                "amount": 1250,
-                "currency": "USD"
-              },
               "netTotalSalesSourceAmountOrZero": {
                 "amount": 1250,
                 "currency": "USD"
@@ -42772,6 +42736,10 @@
                 "currency": "USD"
               },
               "totalPlatformFeeSourceAmount": {
+                "amount": 1250,
+                "currency": "USD"
+              },
+              "totalPaymentProcessingFeeSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
               },
@@ -42786,7 +42754,39 @@
               "totalSupplierAgencyFeesSourceAmount": {
                 "amount": 1250,
                 "currency": "USD"
-              }
+              },
+              "beneficiaryList": [
+                {
+                  "accountIdentifier": "d5b8a3c2-9e6f-4a1b-8d34-7c2e1f0a5b69",
+                  "accountName": "The Siam Residences, Bangkok",
+                  "accountEmail": "reservations@thesiamresidences.com",
+                  "accountUrl": "https://trvl.as/the-siam-residences-bangkok",
+                  "amountDue": {
+                    "percent": 0.05
+                  },
+                  "sourceCurrency": "THB",
+                  "displayCurrency": "USD",
+                  "internalCurrency": "USD",
+                  "sourceAmount": 450,
+                  "displayAmount": 450,
+                  "internalAmount": 450,
+                  "sourceAmountRefundModifier": 45,
+                  "displayAmountRefundModifier": 45,
+                  "internalAmountRefundModifier": 45,
+                  "pendingRefunds": [
+                    {
+                      "refundIdentifier": "ref-d5b8a3c2-9e6f-4a1b-8d34",
+                      "sourceAmountRefundModifier": 45,
+                      "displayAmountRefundModifier": 45,
+                      "internalAmountRefundModifier": 45
+                    }
+                  ],
+                  "netSourceAmount": 450,
+                  "netDisplayAmount": 450,
+                  "netInternalAmount": 450,
+                  "reconciled": false
+                }
+              ]
             }
           ],
           "number": 0,
@@ -43025,8 +43025,8 @@
               "email": "johnsmith@email.com",
               "secondaryEmail": "johnsmith2@email.com",
               "phoneNumber": "+12125551212",
-              "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-              "fullName": "Alexandra Beaumont"
+              "fullName": "Alexandra Beaumont",
+              "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
             }
           ],
           "petInfo": [
@@ -43473,8 +43473,8 @@
                 "email": "johnsmith@email.com",
                 "secondaryEmail": "johnsmith2@email.com",
                 "phoneNumber": "+12125551212",
-                "summary": "John Smith (johnsmith@gmail.com / +12125551212)",
-                "fullName": "Alexandra Beaumont"
+                "fullName": "Alexandra Beaumont",
+                "summary": "John Smith (johnsmith@gmail.com / +12125551212)"
               }
             ],
             "petInfo": [
@@ -44912,8 +44912,8 @@
           "county": "Alameda county",
           "city": "Bangkok",
           "countryCode": "TH",
-          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States",
-          "country": "United States"
+          "country": "United States",
+          "fullAddress": "11 At home, Suite 3C, New York City, NY 10010, United States"
         },
         "properties": {
           "address1": {
@@ -44959,18 +44959,18 @@
             "example": "TH",
             "pattern": "^[A-Z]{2}$"
           },
-          "fullAddress": {
-            "type": "string",
-            "default": "",
-            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
-            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
-            "readOnly": true
-          },
           "country": {
             "type": "string",
             "default": "",
             "description": "Country",
             "example": "United States",
+            "readOnly": true
+          },
+          "fullAddress": {
+            "type": "string",
+            "default": "",
+            "description": "Address 1, Address 2, City, State, Postal / Zip code, Country",
+            "example": "11 At home, Suite 3C, New York City, NY 10010, United States",
             "readOnly": true
           }
         }
@@ -47657,7 +47657,7 @@
         "name": "Client Credentials",
         "flows": {
           "clientCredentials": {
-            "tokenUrl": "https://dev-iam.wink.travel:9000/oauth2/token",
+            "tokenUrl": "https://iam.wink.travel/oauth2/token",
             "scopes": {
               "account.read": "View your account settings.",
               "account.write": "Create and update your account settings.",

--- a/scripts/sync-schemas.ts
+++ b/scripts/sync-schemas.ts
@@ -159,15 +159,25 @@ const PARTNER_SCHEMA_FILE = resolve(
   MONOREPO_PATH, "open-api/open-api-grpc/target/openapi/partner.json"
 );
 
+// integrations-app's channel-manager document, generated the same way but by a different mechanism: a
+// Spring MVC surface has no descriptor, so springdoc reads the annotations from a hand-assembled web
+// context in IntegrationsOpenApiSpecWriterTest. Produced by SUREFIRE, so a `-DskipTests` build does not
+// create it -- see the OpenAPI schema artifacts section in monorepo-java's CLAUDE.md.
+const INTEGRATIONS_SCHEMA_DIR = resolve(MONOREPO_PATH, "apps/integrations-app/target/openapi");
+
 const targets: readonly SchemaTarget[] = [
   ...INVENTORY_GROUPS.map((group) => ({
     name: group,
     source: { kind: "url" as const, url: `${API_BASE}/v3/api-docs/${group}` },
     outFile: `${group}.json`,
   })),
+  // Read, not fetched -- same reasoning as partner below. INTEGRATIONS_BASE is deliberately unused.
   ...INTEGRATIONS_GROUPS.map(({ group, audience }) => ({
     name: audience,
-    source: { kind: "url" as const, url: `${INTEGRATIONS_BASE}/v3/api-docs/${group}` },
+    source: {
+      kind: "file" as const,
+      path: resolve(INTEGRATIONS_SCHEMA_DIR, `${group}.json`),
+    },
     outFile: `${audience}.json`,
   })),
   // Read, not fetched, so PARTNER_BASE is deliberately unused here -- see SchemaSource. This works for
@@ -301,7 +311,7 @@ const main = async (): Promise<void> => {
   console.log(
     `Syncing schemas from ${ENV}\n` +
     `  api          = ${API_BASE}\n` +
-    `  integrations = ${INTEGRATIONS_BASE}\n` +
+    `  integrations = ${INTEGRATIONS_SCHEMA_DIR} (build output, environment-independent)\n` +
     `  partner      = ${PARTNER_SCHEMA_FILE} (build output, environment-independent)\n`
   );
 
@@ -312,7 +322,7 @@ const main = async (): Promise<void> => {
   // reader running schemas:sync:staging would reasonably assume otherwise.
   if (ENV !== "production") {
     console.warn(
-      `⚠ partner is read from a build artifact and ignores --env=${ENV}. Its Authentication section\n` +
+      `⚠ partner and integrations are read from build artifacts and ignore --env=${ENV}. Its Authentication section\n` +
       `  always carries the PRODUCTION issuer, because that is what open-api-grpc's exec plugin bakes\n` +
       `  in. Only the ${ENV} API and integrations schemas below are actually ${ENV}.\n`
     );


### PR DESCRIPTION
## The urgent half

**Every published schema except `partner` advertised dev hosts and a dev token endpoint.**

```
server   https://dev-api.wink.travel:8443 / https://dev-integrations.wink.travel:8445
tokenUrl https://dev-iam.wink.travel:9000/oauth2/token
```

The public reference told integrators to authenticate against a **dev IAM server on port 9000** and call
hosts unreachable from outside the network. For a paid API those are the integration instructions.

Cause: `schemas:sync` takes an `--env` and the committed snapshots carry whatever it was pointed at.
Someone synced against local/dev and committed it — the files were stamped `33.0.2-SNAPSHOT`, so this has
been live for a while. `partner` was unaffected because its document is generated at build time with the
production issuer baked in.

Re-synced against production. **No path count changed in any of the twelve** — the content was already
right, it was addressed to the wrong place.

## The structural half

`channel-manager` now comes from monorepo-java's build output instead of a fetch, joining `partner`.

A build artifact cannot be pointed at the wrong environment: it is generated from the code with
production values and is environment-independent by construction. That is the actual fix for the defect
above, rather than re-syncing and hoping.

Generated by `IntegrationsOpenApiSpecWriterTest`, which assembles the minimum Spring context springdoc
needs — no application, no MongoDB, no Redis, no servlet container. Verified identical to production:
6 paths, 13 schemas, 70 responses across ten status codes.

**Pairs with monorepo-java's `feature/openapi-build-time-slice`.**

## Still fetched

Ten schemas from inventory-app. They need the same treatment (261 paths in `extranet` alone) or, cheaper,
a fetch triggered on **deploy success** rather than on demand.

## Test plan

- [x] all 12 schemas now advertise production servers and `iam.wink.travel`
- [x] no path count changed in any schema
- [x] `tsc --noEmit` clean; sync runs end to end, 12/12
- [x] channel-manager read from the build artifact, not fetched
- [ ] confirm the rendered docs site shows production URLs after merge