### PR TITLE
feat(docs): publish the platform taxonomy as a static reference page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,35 @@ The site uses these Starlight plugins (see `astro.config.mjs`):
 
 Sidebar is explicitly listed in `astro.config.mjs` (not fully auto-generated): each top-level group is `autogenerate`'d from a directory under `src/content/docs/`, and a single "API" group (containing the `apiSidebarGroup` placeholder) appears immediately after Developers. Adding a new top-level docs section requires editing the `sidebar` array.
 
+### Taxonomy (Developers > Taxonomy)
+
+`src/data/taxonomy.json` holds the platform's three controlled vocabularies — OTA codes (25 categories,
+1,475 codes), supported languages (44), supported currencies (164) — rendered by
+`src/content/docs/developers/taxonomy.mdx` via the components in `src/components/taxonomy/`.
+
+**The values are HARDCODED here on purpose, and this repo is becoming their published home.** They are
+not synced from monorepo-java and there is no `taxonomy:sync` script, because the backend endpoints that
+used to serve them (`/reference-data/ota/list`, `/reference-data/ota/{category}`,
+`/reference-data/language/list`, `/reference-data/currency/list`) are being retired now that this page
+exists. A sync script would point the dependency back at the thing being removed.
+
+Their original upstreams, for the record — useful when reconciling a change, not as a build input:
+
+| vocabulary | was |
+|---|---|
+| OTA codes | `reference/reference-domain/src/main/resources/ota/*.json` (still used at runtime for code→label resolution in booking emails, PDFs, lead suggestions, embeddings — those stay) |
+| languages | `platform.supported-languages` in `apps/inventory-app/src/main/resources/application.properties` |
+| currencies | `platform.supported-currencies`, same file |
+
+`taxonomy.json` carries **no timestamp**, so regenerating it produces a diff only when a value actually
+changed — a "nothing moved" commit is indistinguishable from a real contract change otherwise.
+
+Component chrome (table headers, the "No standard name" placeholder) is passed in as **props from the
+MDX**, never hardcoded in the `.astro` files. `translate-i18n.ts` translates whole MDX files and never
+opens a component, so a header written inside `code-table.astro` would stay English in all 40+ locales
+with nothing to flag it. The code values themselves are deliberately outside the MDX so translation
+cannot touch them — a translated OTA code is a broken one.
+
 ## Important Patterns
 
 **Splash Pages:** Use template: splash in frontmatter and import marketing components

--- a/src/components/taxonomy/code-table.astro
+++ b/src/components/taxonomy/code-table.astro
@@ -1,0 +1,60 @@
+---
+/*
+ * Copyright (c) wink.travel 2026
+ */
+// A two-column code/name table, used for the supported-language and supported-currency lists.
+//
+// Every human-readable string is a PROP rather than a literal. scripts/translate-i18n.ts translates
+// whole MDX files and never opens a .astro component, so a header hardcoded here would stay English
+// in all 40+ locales with nothing to flag it. Passing them in from the calling MDX puts them inside
+// the file the translation pipeline actually reads.
+
+interface Props {
+  rows: ReadonlyArray<{ readonly code: string; readonly name: string | null }>;
+  codeHeader: string;
+  nameHeader: string;
+  /** Rendered in the name cell when CLDR has no English name for the code. */
+  unnamedLabel: string;
+}
+
+const { rows, codeHeader, nameHeader, unnamedLabel } = Astro.props;
+---
+
+<div class="taxonomy-scroll">
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">{codeHeader}</th>
+        <th scope="col">{nameHeader}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map(({ code, name }) => (
+        <tr>
+          <td><code>{code}</code></td>
+          <td>{name ?? <em>{unnamedLabel}</em>}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  /* Long vocabularies scroll inside their own box rather than widening the page. */
+  .taxonomy-scroll {
+    max-height: 30rem;
+    overflow: auto;
+  }
+
+  .taxonomy-scroll table {
+    margin: 0;
+    width: 100%;
+  }
+
+  .taxonomy-scroll thead th {
+    background: var(--sl-color-black);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+</style>

--- a/src/components/taxonomy/ota-categories.astro
+++ b/src/components/taxonomy/ota-categories.astro
@@ -1,0 +1,133 @@
+---
+/*
+ * Copyright (c) wink.travel 2026
+ */
+// Renders the OTA vocabulary: an index of the categories, then one collapsible block per category
+// holding its codes.
+//
+// Collapsed by default because the full vocabulary is ~1,475 rows. Built with <details>, so it works
+// with no JavaScript and the browser's own in-page find still reaches a closed section in Chromium
+// (hidden="until-found"); the anchors in the index open the target section natively.
+//
+// Human-readable chrome arrives as PROPS rather than literals. scripts/translate-i18n.ts translates
+// whole MDX files and never opens a .astro component, so a header hardcoded here would stay English
+// in all 40+ locales with nothing to flag it.
+
+interface OtaCategory {
+  readonly code: string;
+  readonly label: string;
+  readonly codes: ReadonlyArray<{ readonly value: string; readonly label: string }>;
+}
+
+interface Props {
+  categories: ReadonlyArray<OtaCategory>;
+  categoryHeader: string;
+  descriptionHeader: string;
+  countHeader: string;
+  codeHeader: string;
+  nameHeader: string;
+}
+
+const {
+  categories,
+  categoryHeader,
+  descriptionHeader,
+  countHeader,
+  codeHeader,
+  nameHeader,
+} = Astro.props;
+
+const anchorFor = (code: string): string => `ota-${code.toLowerCase()}`;
+---
+
+<div class="taxonomy-scroll">
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">{categoryHeader}</th>
+        <th scope="col">{descriptionHeader}</th>
+        <th scope="col">{countHeader}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {categories.map(({ code, label, codes }) => (
+        <tr>
+          <td><a href={`#${anchorFor(code)}`}><code>{code}</code></a></td>
+          <td>{label}</td>
+          <td>{codes.length}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>
+
+{categories.map(({ code, label, codes }) => (
+  <details id={anchorFor(code)} class="taxonomy-category">
+    <summary>
+      <code>{code}</code> — {label} <span class="taxonomy-count">({codes.length})</span>
+    </summary>
+    <div class="taxonomy-scroll">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">{codeHeader}</th>
+            <th scope="col">{nameHeader}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {codes.map(({ value, label: name }) => (
+            <tr>
+              <td><code>{value}</code></td>
+              <td>{name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </details>
+))}
+
+<style>
+  .taxonomy-scroll {
+    max-height: 30rem;
+    overflow: auto;
+  }
+
+  .taxonomy-scroll table {
+    margin: 0;
+    width: 100%;
+  }
+
+  .taxonomy-scroll thead th {
+    background: var(--sl-color-black);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .taxonomy-category {
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.25rem;
+    margin-block: 0.5rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .taxonomy-category > summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .taxonomy-category[open] > summary {
+    margin-block-end: 0.5rem;
+  }
+
+  .taxonomy-count {
+    color: var(--sl-color-gray-3);
+    font-weight: 400;
+  }
+
+  /* Anchored category lands below the sticky header instead of under it. */
+  .taxonomy-category:target {
+    scroll-margin-top: 6rem;
+  }
+</style>

--- a/src/content/docs/developers/taxonomy.mdx
+++ b/src/content/docs/developers/taxonomy.mdx
@@ -1,0 +1,81 @@
+---
+title: Taxonomy
+description: The controlled vocabularies the Wink platform uses — OTA codes for amenities, bed types, room views and more, plus every supported language and currency.
+sidebar:
+  order: 12
+---
+
+import taxonomy from '@/data/taxonomy.json';
+import OtaCategories from '@/components/taxonomy/ota-categories.astro';
+import CodeTable from '@/components/taxonomy/code-table.astro';
+
+Wink describes inventory using controlled vocabularies — fixed sets of codes with agreed meanings. When
+you send `"5"` as a hotel amenity, the platform reads it as *Air conditioning*, and every consumer of
+that data does too.
+
+This page is the published reference for all three vocabularies:
+
+- **OTA codes** — {taxonomy.ota.codeCount} codes across {taxonomy.ota.categoryCount} categories, covering
+  amenities, bed types, room views, accessibility features, cuisine, and more.
+- **Languages** — the {taxonomy.languages.list.length} languages content can be authored and served in.
+- **Currencies** — the {taxonomy.currencies.list.length} currencies rates can be quoted and settled in.
+
+Codes are stable. Names may be reworded for clarity, so match on the **code**, never on the name.
+
+## OTA codes
+
+Wink follows the [OpenTravel Alliance](https://opentravel.org/) code lists. Each category has a
+three-letter identifier — `HAC` for hotel amenities, `BED` for bed types — and every code within a
+category is unique to it. The same numeric value means different things in different categories, so a
+code is only meaningful alongside the category it belongs to: `BED` `1` is *Double / Full*, while `HAC`
+`1` is *24-hour front desk*.
+
+Select a category to see its codes.
+
+<OtaCategories
+  categories={taxonomy.ota.categories}
+  categoryHeader="Category"
+  descriptionHeader="Description"
+  countHeader="Codes"
+  codeHeader="Code"
+  nameHeader="Name"
+/>
+
+## Languages
+
+Content — property descriptions, room names, policies — can be authored in any of these languages.
+Codes are [IETF BCP 47](https://www.rfc-editor.org/info/bcp47) tags: a two-letter
+[ISO 639-1](https://www.iso.org/iso-639-language-code) language, optionally followed by an
+[ISO 3166-1](https://www.iso.org/iso-3166-country-codes.html) region where the platform distinguishes
+regional variants — `pt-BR` and `pt-PT` are carried separately, as are `es`, `es-AR`, and `es-MX`.
+
+The platform default is `{taxonomy.languages.default}`, used when a request specifies no language and
+when a translation is unavailable.
+
+<CodeTable
+  rows={taxonomy.languages.list}
+  codeHeader="Code"
+  nameHeader="Language"
+  unnamedLabel="No standard name"
+/>
+
+## Currencies
+
+Rates can be quoted and settled in any of these currencies. Codes are
+[ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-letter identifiers.
+
+The platform default is `{taxonomy.currencies.default}`. It is the fallback display currency and the
+unit platform-level figures are normalised to; it is **not** the currency a booking settles in — hotels
+settle in their own currency, so a rate quoted in one currency and paid in another carries an exchange
+spread.
+
+A few entries are not national currencies: `XAU` and `XAG` are gold and silver, `XDR` is the IMF's
+Special Drawing Right, and `BTC` is Bitcoin. These are carried for valuation and reporting, and are not
+generally usable as a settlement currency.
+
+<CodeTable
+  rows={taxonomy.currencies.list}
+  codeHeader="Code"
+  nameHeader="Currency"
+  unnamedLabel="No standard name"
+/>

--- a/src/data/taxonomy.json
+++ b/src/data/taxonomy.json
@@ -1,0 +1,6900 @@
+{
+  "ota": {
+    "categoryCount": 25,
+    "codeCount": 1475,
+    "categories": [
+      {
+        "code": "ACC",
+        "label": "Attraction category codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Airport"
+          },
+          {
+            "value": "2",
+            "label": "Amusement park"
+          },
+          {
+            "value": "3",
+            "label": "Aquarium"
+          },
+          {
+            "value": "4",
+            "label": "Auditorium"
+          },
+          {
+            "value": "5",
+            "label": "Beach"
+          },
+          {
+            "value": "7",
+            "label": "Bridge"
+          },
+          {
+            "value": "8",
+            "label": "Bus station"
+          },
+          {
+            "value": "9",
+            "label": "Business location"
+          },
+          {
+            "value": "10",
+            "label": "Canal"
+          },
+          {
+            "value": "11",
+            "label": "Car rental location"
+          },
+          {
+            "value": "12",
+            "label": "Casino"
+          },
+          {
+            "value": "13",
+            "label": "Cemetery"
+          },
+          {
+            "value": "14",
+            "label": "Church"
+          },
+          {
+            "value": "15",
+            "label": "Concert hall"
+          },
+          {
+            "value": "16",
+            "label": "Conference center"
+          },
+          {
+            "value": "17",
+            "label": "Convention center"
+          },
+          {
+            "value": "18",
+            "label": "Entertainment district"
+          },
+          {
+            "value": "19",
+            "label": "Factory"
+          },
+          {
+            "value": "20",
+            "label": "Fairground"
+          },
+          {
+            "value": "21",
+            "label": "Farm"
+          },
+          {
+            "value": "22",
+            "label": "Gallery"
+          },
+          {
+            "value": "23",
+            "label": "Historic building"
+          },
+          {
+            "value": "24",
+            "label": "Hospital"
+          },
+          {
+            "value": "25",
+            "label": "Lake"
+          },
+          {
+            "value": "26",
+            "label": "Landmark"
+          },
+          {
+            "value": "27",
+            "label": "Library"
+          },
+          {
+            "value": "28",
+            "label": "Marina"
+          },
+          {
+            "value": "29",
+            "label": "Market"
+          },
+          {
+            "value": "30",
+            "label": "Monument"
+          },
+          {
+            "value": "31",
+            "label": "Mountain"
+          },
+          {
+            "value": "32",
+            "label": "Museum"
+          },
+          {
+            "value": "33",
+            "label": "Ocean"
+          },
+          {
+            "value": "34",
+            "label": "Orchard"
+          },
+          {
+            "value": "35",
+            "label": "Palace"
+          },
+          {
+            "value": "36",
+            "label": "Park"
+          },
+          {
+            "value": "37",
+            "label": "Pier"
+          },
+          {
+            "value": "38",
+            "label": "Race track"
+          },
+          {
+            "value": "39",
+            "label": "Recreation center"
+          },
+          {
+            "value": "40",
+            "label": "Resort"
+          },
+          {
+            "value": "41",
+            "label": "Restaurant"
+          },
+          {
+            "value": "42",
+            "label": "River"
+          },
+          {
+            "value": "43",
+            "label": "School"
+          },
+          {
+            "value": "44",
+            "label": "Shopping mall"
+          },
+          {
+            "value": "45",
+            "label": "Ski area"
+          },
+          {
+            "value": "46",
+            "label": "Stadium"
+          },
+          {
+            "value": "47",
+            "label": "Store"
+          },
+          {
+            "value": "48",
+            "label": "Studio"
+          },
+          {
+            "value": "49",
+            "label": "Subway station"
+          },
+          {
+            "value": "50",
+            "label": "Theater / Cinema"
+          },
+          {
+            "value": "51",
+            "label": "Train station"
+          },
+          {
+            "value": "52",
+            "label": "Trolley station"
+          },
+          {
+            "value": "53",
+            "label": "University"
+          },
+          {
+            "value": "54",
+            "label": "Water park"
+          },
+          {
+            "value": "55",
+            "label": "Waterfront"
+          },
+          {
+            "value": "56",
+            "label": "Winery"
+          },
+          {
+            "value": "57",
+            "label": "Zoo"
+          },
+          {
+            "value": "58",
+            "label": "Event"
+          },
+          {
+            "value": "59",
+            "label": "Festival"
+          },
+          {
+            "value": "60",
+            "label": "Tournament"
+          },
+          {
+            "value": "61",
+            "label": "Tour"
+          },
+          {
+            "value": "62",
+            "label": "Other"
+          },
+          {
+            "value": "63",
+            "label": "College"
+          },
+          {
+            "value": "64",
+            "label": "Nightlife"
+          },
+          {
+            "value": "65",
+            "label": "Shopping  "
+          },
+          {
+            "value": "66",
+            "label": "Sports"
+          },
+          {
+            "value": "67",
+            "label": "City center"
+          },
+          {
+            "value": "70",
+            "label": "Port"
+          },
+          {
+            "value": "71",
+            "label": "Live theatre"
+          },
+          {
+            "value": "72",
+            "label": "Arena"
+          },
+          {
+            "value": "73",
+            "label": "Bar"
+          },
+          {
+            "value": "74",
+            "label": "Bay"
+          },
+          {
+            "value": "75",
+            "label": "Cathedral"
+          },
+          {
+            "value": "77",
+            "label": "Educational institution"
+          },
+          {
+            "value": "78",
+            "label": "Financial district"
+          },
+          {
+            "value": "79",
+            "label": "Financial institution"
+          },
+          {
+            "value": "80",
+            "label": "Medical facility"
+          },
+          {
+            "value": "81",
+            "label": "Mosque"
+          },
+          {
+            "value": "82",
+            "label": "Synagogue"
+          },
+          {
+            "value": "83",
+            "label": "Suburb"
+          },
+          {
+            "value": "85",
+            "label": "Commercial district"
+          },
+          {
+            "value": "86",
+            "label": "Tourist site"
+          },
+          {
+            "value": "88",
+            "label": "Agricultural"
+          },
+          {
+            "value": "89",
+            "label": "Archeological"
+          },
+          {
+            "value": "90",
+            "label": "Botanical garden"
+          },
+          {
+            "value": "91",
+            "label": "Bowling"
+          },
+          {
+            "value": "92",
+            "label": "Cultural center"
+          },
+          {
+            "value": "93",
+            "label": "Equestrian center"
+          },
+          {
+            "value": "94",
+            "label": "Handicraft center"
+          },
+          {
+            "value": "95",
+            "label": "Natural attraction"
+          },
+          {
+            "value": "96",
+            "label": "Performing art center"
+          },
+          {
+            "value": "97",
+            "label": "Planetarium / Science center"
+          },
+          {
+            "value": "98",
+            "label": "Cable cars"
+          },
+          {
+            "value": "99",
+            "label": "Company"
+          },
+          {
+            "value": "100",
+            "label": "Factory / Business tour"
+          },
+          {
+            "value": "102",
+            "label": "Local bus stop"
+          },
+          {
+            "value": "103",
+            "label": "Convention and visitors bureau"
+          },
+          {
+            "value": "104",
+            "label": "Art"
+          },
+          {
+            "value": "105",
+            "label": "Music"
+          },
+          {
+            "value": "106",
+            "label": "State / National Park"
+          },
+          {
+            "value": "108",
+            "label": "Non-commercial airport"
+          }
+        ]
+      },
+      {
+        "code": "AQC",
+        "label": "Age qualifying codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Over 21"
+          },
+          {
+            "value": "2",
+            "label": "Over 65"
+          },
+          {
+            "value": "3",
+            "label": "Under 2"
+          },
+          {
+            "value": "4",
+            "label": "Under 12"
+          },
+          {
+            "value": "5",
+            "label": "Under 17"
+          },
+          {
+            "value": "6",
+            "label": "Under 21"
+          },
+          {
+            "value": "7",
+            "label": "Infant"
+          },
+          {
+            "value": "8",
+            "label": "Child"
+          },
+          {
+            "value": "9",
+            "label": "Teenager"
+          },
+          {
+            "value": "10",
+            "label": "Adult"
+          },
+          {
+            "value": "11",
+            "label": "Senior "
+          },
+          {
+            "value": "18",
+            "label": "Under 10"
+          }
+        ]
+      },
+      {
+        "code": "ARC",
+        "label": "Architectural style codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Art deco"
+          },
+          {
+            "value": "2",
+            "label": "Brazilian"
+          },
+          {
+            "value": "3",
+            "label": "Contemporary"
+          },
+          {
+            "value": "4",
+            "label": "High rise"
+          },
+          {
+            "value": "5",
+            "label": "Historic"
+          },
+          {
+            "value": "6",
+            "label": "Mediterranean"
+          },
+          {
+            "value": "7",
+            "label": "Modern"
+          },
+          {
+            "value": "8",
+            "label": "Asian"
+          },
+          {
+            "value": "9",
+            "label": "Southwestern"
+          },
+          {
+            "value": "10",
+            "label": "Traditional"
+          },
+          {
+            "value": "11",
+            "label": "Victorian"
+          },
+          {
+            "value": "12",
+            "label": "Western"
+          },
+          {
+            "value": "13",
+            "label": "Ancient"
+          },
+          {
+            "value": "14",
+            "label": "Themed"
+          }
+        ]
+      },
+      {
+        "code": "BED",
+        "label": "Bed type codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Double / Full"
+          },
+          {
+            "value": "2",
+            "label": "Futon"
+          },
+          {
+            "value": "3",
+            "label": "King"
+          },
+          {
+            "value": "4",
+            "label": "Murphy"
+          },
+          {
+            "value": "5",
+            "label": "Queen"
+          },
+          {
+            "value": "6",
+            "label": "Sofa bed"
+          },
+          {
+            "value": "7",
+            "label": "Tatami mats"
+          },
+          {
+            "value": "8",
+            "label": "Twin"
+          },
+          {
+            "value": "9",
+            "label": "Single"
+          },
+          {
+            "value": "10",
+            "label": "Full"
+          },
+          {
+            "value": "11",
+            "label": "Run of the house"
+          },
+          {
+            "value": "12",
+            "label": "Dorm bed"
+          },
+          {
+            "value": "13",
+            "label": "Water bed"
+          }
+        ]
+      },
+      {
+        "code": "CUI",
+        "label": "Cuisine codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "American"
+          },
+          {
+            "value": "2",
+            "label": "French"
+          },
+          {
+            "value": "3",
+            "label": "Italian"
+          },
+          {
+            "value": "4",
+            "label": "Seafood"
+          },
+          {
+            "value": "5",
+            "label": "Indian"
+          },
+          {
+            "value": "6",
+            "label": "Asian"
+          },
+          {
+            "value": "8",
+            "label": "Mexican"
+          },
+          {
+            "value": "9",
+            "label": "Greek"
+          },
+          {
+            "value": "10",
+            "label": "Thai"
+          },
+          {
+            "value": "11",
+            "label": "Chinese"
+          },
+          {
+            "value": "12",
+            "label": "Vietnamese"
+          },
+          {
+            "value": "13",
+            "label": "Middle Eastern"
+          },
+          {
+            "value": "14",
+            "label": "Japanese"
+          },
+          {
+            "value": "15",
+            "label": "Moroccan"
+          },
+          {
+            "value": "16",
+            "label": "Deli"
+          },
+          {
+            "value": "17",
+            "label": "European"
+          },
+          {
+            "value": "18",
+            "label": "Ethiopian"
+          },
+          {
+            "value": "19",
+            "label": "Spanish"
+          },
+          {
+            "value": "20",
+            "label": "Tapas"
+          },
+          {
+            "value": "21",
+            "label": "Afghan"
+          },
+          {
+            "value": "22",
+            "label": "Turkish"
+          },
+          {
+            "value": "23",
+            "label": "Russian"
+          },
+          {
+            "value": "24",
+            "label": "German"
+          },
+          {
+            "value": "25",
+            "label": "Southwest US"
+          },
+          {
+            "value": "26",
+            "label": "TexMex"
+          },
+          {
+            "value": "27",
+            "label": "California"
+          },
+          {
+            "value": "28",
+            "label": "Hawaiian"
+          },
+          {
+            "value": "29",
+            "label": "Irish"
+          },
+          {
+            "value": "30",
+            "label": "Scottish"
+          },
+          {
+            "value": "31",
+            "label": "English"
+          },
+          {
+            "value": "32",
+            "label": "Lebanese"
+          },
+          {
+            "value": "33",
+            "label": "Argentinean"
+          },
+          {
+            "value": "34",
+            "label": "Brazilian"
+          },
+          {
+            "value": "35",
+            "label": "Caribbean"
+          },
+          {
+            "value": "36",
+            "label": "Mongolian"
+          },
+          {
+            "value": "37",
+            "label": "Southern US"
+          },
+          {
+            "value": "38",
+            "label": "Soul food"
+          },
+          {
+            "value": "39",
+            "label": "Barbeque"
+          },
+          {
+            "value": "40",
+            "label": "Cajun"
+          },
+          {
+            "value": "41",
+            "label": "Creole"
+          },
+          {
+            "value": "42",
+            "label": "Korean"
+          },
+          {
+            "value": "43",
+            "label": "Latin American"
+          },
+          {
+            "value": "44",
+            "label": "Steak houses"
+          },
+          {
+            "value": "45",
+            "label": "Coffee shop"
+          },
+          {
+            "value": "46",
+            "label": "Continental"
+          },
+          {
+            "value": "47",
+            "label": "Eclectic"
+          },
+          {
+            "value": "49",
+            "label": "International"
+          },
+          {
+            "value": "50",
+            "label": "Jewish"
+          },
+          {
+            "value": "51",
+            "label": "Mediterranean"
+          },
+          {
+            "value": "52",
+            "label": "Other"
+          },
+          {
+            "value": "53",
+            "label": "Pizza"
+          },
+          {
+            "value": "54",
+            "label": "Sandwiches"
+          },
+          {
+            "value": "55",
+            "label": "South American"
+          },
+          {
+            "value": "56",
+            "label": "Swiss"
+          },
+          {
+            "value": "57",
+            "label": "Vegetarian"
+          },
+          {
+            "value": "58",
+            "label": "Halal"
+          },
+          {
+            "value": "59",
+            "label": "Asian-Fusion"
+          },
+          {
+            "value": "60",
+            "label": "Pub"
+          },
+          {
+            "value": "61",
+            "label": "Bavarian"
+          },
+          {
+            "value": "62",
+            "label": "High-tea"
+          },
+          {
+            "value": "63",
+            "label": "Muslim"
+          },
+          {
+            "value": "64",
+            "label": "Polynesian"
+          },
+          {
+            "value": "65",
+            "label": "Scandinavian"
+          },
+          {
+            "value": "66",
+            "label": "Austrian"
+          },
+          {
+            "value": "67",
+            "label": "Modern Australian"
+          },
+          {
+            "value": "68",
+            "label": "Kosher"
+          },
+          {
+            "value": "69",
+            "label": "Pacific rim"
+          },
+          {
+            "value": "70",
+            "label": "Mixed - cafeteria"
+          },
+          {
+            "value": "71",
+            "label": "Iranian"
+          },
+          {
+            "value": "72",
+            "label": "Modern Azerbaijan"
+          },
+          {
+            "value": "73",
+            "label": "Indonesian"
+          },
+          {
+            "value": "74",
+            "label": "Grill"
+          },
+          {
+            "value": "75",
+            "label": "Canadian"
+          },
+          {
+            "value": "76",
+            "label": "Polish"
+          },
+          {
+            "value": "77",
+            "label": "Multiple"
+          }
+        ]
+      },
+      {
+        "code": "GRI",
+        "label": "Guest room info",
+        "codes": [
+          {
+            "value": "38",
+            "label": "Cabin"
+          },
+          {
+            "value": "39",
+            "label": "Cottage"
+          },
+          {
+            "value": "40",
+            "label": "Loft"
+          },
+          {
+            "value": "42",
+            "label": "Room"
+          },
+          {
+            "value": "43",
+            "label": "Lanai"
+          },
+          {
+            "value": "44",
+            "label": "Bungalow"
+          },
+          {
+            "value": "45",
+            "label": "Villa"
+          },
+          {
+            "value": "48",
+            "label": "Double double bedrooms"
+          },
+          {
+            "value": "49",
+            "label": "King king bedrooms"
+          },
+          {
+            "value": "50",
+            "label": "Queen queen bedrooms"
+          },
+          {
+            "value": "51",
+            "label": "Twin twin bedrooms"
+          },
+          {
+            "value": "52",
+            "label": "Apartment for 1"
+          },
+          {
+            "value": "53",
+            "label": "Apartment for 2"
+          },
+          {
+            "value": "54",
+            "label": "Apartment for 3"
+          },
+          {
+            "value": "55",
+            "label": "Apartment for 4"
+          },
+          {
+            "value": "56",
+            "label": "Apartment for 6"
+          },
+          {
+            "value": "60",
+            "label": "Junior suite"
+          },
+          {
+            "value": "61",
+            "label": "Jacuzzi suite"
+          },
+          {
+            "value": "62",
+            "label": "Run of the house"
+          },
+          {
+            "value": "63",
+            "label": "Large suite"
+          },
+          {
+            "value": "64",
+            "label": "1 bedroom"
+          },
+          {
+            "value": "65",
+            "label": "2 bedroom"
+          },
+          {
+            "value": "66",
+            "label": "3 bedroom"
+          },
+          {
+            "value": "67",
+            "label": "Villa for 1"
+          },
+          {
+            "value": "68",
+            "label": "Villa for 2"
+          },
+          {
+            "value": "69",
+            "label": "Villa for 3"
+          },
+          {
+            "value": "70",
+            "label": "Villa for 6"
+          },
+          {
+            "value": "71",
+            "label": "Villa for 8"
+          },
+          {
+            "value": "72",
+            "label": "Pullout"
+          },
+          {
+            "value": "75",
+            "label": "Classic"
+          },
+          {
+            "value": "76",
+            "label": "Comfort"
+          },
+          {
+            "value": "77",
+            "label": "Deluxe"
+          },
+          {
+            "value": "78",
+            "label": "Deluxe suite"
+          },
+          {
+            "value": "79",
+            "label": "Economy"
+          },
+          {
+            "value": "80",
+            "label": "Luxury"
+          },
+          {
+            "value": "81",
+            "label": "Premier"
+          },
+          {
+            "value": "82",
+            "label": "Standard"
+          },
+          {
+            "value": "83",
+            "label": "Superior"
+          }
+        ]
+      },
+      {
+        "code": "HAC",
+        "label": "Hotel amenity codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "24-hour front desk"
+          },
+          {
+            "value": "5",
+            "label": "Air conditioning"
+          },
+          {
+            "value": "6",
+            "label": "Airline desk"
+          },
+          {
+            "value": "7",
+            "label": "ATM/Cash machine"
+          },
+          {
+            "value": "8",
+            "label": "Baby sitting"
+          },
+          {
+            "value": "9",
+            "label": "BBQ/Picnic area"
+          },
+          {
+            "value": "12",
+            "label": "Boutiques/stores"
+          },
+          {
+            "value": "14",
+            "label": "Business library"
+          },
+          {
+            "value": "15",
+            "label": "Car rental desk"
+          },
+          {
+            "value": "16",
+            "label": "Casino"
+          },
+          {
+            "value": "17",
+            "label": "Check cashing policy"
+          },
+          {
+            "value": "18",
+            "label": "Check-in kiosk"
+          },
+          {
+            "value": "19",
+            "label": "Cocktail lounge"
+          },
+          {
+            "value": "20",
+            "label": "Coffee shop"
+          },
+          {
+            "value": "22",
+            "label": "Concierge desk"
+          },
+          {
+            "value": "23",
+            "label": "Concierge floor"
+          },
+          {
+            "value": "24",
+            "label": "Conference facilities"
+          },
+          {
+            "value": "25",
+            "label": "Courtyard"
+          },
+          {
+            "value": "26",
+            "label": "Currency exchange"
+          },
+          {
+            "value": "29",
+            "label": "Door man"
+          },
+          {
+            "value": "33",
+            "label": "Elevators"
+          },
+          {
+            "value": "34",
+            "label": "Executive floor"
+          },
+          {
+            "value": "35",
+            "label": "Fitness facilities"
+          },
+          {
+            "value": "36",
+            "label": "Express check-in"
+          },
+          {
+            "value": "37",
+            "label": "Express check-out"
+          },
+          {
+            "value": "41",
+            "label": "Free airport shuttle"
+          },
+          {
+            "value": "42",
+            "label": "Free parking"
+          },
+          {
+            "value": "44",
+            "label": "Game room"
+          },
+          {
+            "value": "45",
+            "label": "Gift/News stand"
+          },
+          {
+            "value": "46",
+            "label": "Hairdresser/barber"
+          },
+          {
+            "value": "47",
+            "label": "Accessible facilities"
+          },
+          {
+            "value": "50",
+            "label": "Housekeeping "
+          },
+          {
+            "value": "52",
+            "label": "Ice machine"
+          },
+          {
+            "value": "53",
+            "label": "Indoor parking"
+          },
+          {
+            "value": "57",
+            "label": "Kennels"
+          },
+          {
+            "value": "58",
+            "label": "Laundry / Valet service"
+          },
+          {
+            "value": "60",
+            "label": "Live entertainment"
+          },
+          {
+            "value": "62",
+            "label": "Nightclub"
+          },
+          {
+            "value": "65",
+            "label": "Outdoor parking"
+          },
+          {
+            "value": "68",
+            "label": "Parking"
+          },
+          {
+            "value": "71",
+            "label": "Pool"
+          },
+          {
+            "value": "75",
+            "label": "Recreational vehicle parking"
+          },
+          {
+            "value": "76",
+            "label": "Restaurant"
+          },
+          {
+            "value": "77",
+            "label": "Room service"
+          },
+          {
+            "value": "78",
+            "label": "Safe deposit box"
+          },
+          {
+            "value": "80",
+            "label": "Security"
+          },
+          {
+            "value": "81",
+            "label": "Shoe shine stand"
+          },
+          {
+            "value": "87",
+            "label": "Storage space"
+          },
+          {
+            "value": "88",
+            "label": "Sundry / Convenience store"
+          },
+          {
+            "value": "89",
+            "label": "Technical concierge"
+          },
+          {
+            "value": "90",
+            "label": "Theatre desk"
+          },
+          {
+            "value": "91",
+            "label": "Tour / Sightseeing desk"
+          },
+          {
+            "value": "93",
+            "label": "Travel agency"
+          },
+          {
+            "value": "94",
+            "label": "Truck parking"
+          },
+          {
+            "value": "95",
+            "label": "Valet cleaning"
+          },
+          {
+            "value": "96",
+            "label": "Dry cleaning"
+          },
+          {
+            "value": "97",
+            "label": "Valet parking "
+          },
+          {
+            "value": "98",
+            "label": "Vending machines"
+          },
+          {
+            "value": "99",
+            "label": "Media library"
+          },
+          {
+            "value": "103",
+            "label": "Multilingual staff"
+          },
+          {
+            "value": "100",
+            "label": "Wakeup service"
+          },
+          {
+            "value": "106",
+            "label": "Bell staff"
+          },
+          {
+            "value": "108",
+            "label": "Self service laundry"
+          },
+          {
+            "value": "118",
+            "label": "Barbecue grills"
+          },
+          {
+            "value": "122",
+            "label": "Shops and commercial services"
+          },
+          {
+            "value": "132",
+            "label": "Public area air conditioned"
+          },
+          {
+            "value": "133",
+            "label": "Efolio available"
+          },
+          {
+            "value": "135",
+            "label": "Video review billing"
+          },
+          {
+            "value": "136",
+            "label": "Butler service"
+          },
+          {
+            "value": "139",
+            "label": "Complimentary cocktails"
+          },
+          {
+            "value": "143",
+            "label": "Dinner delivery service from local restaurant"
+          },
+          {
+            "value": "144",
+            "label": "Complimentary newspaper delivered to room"
+          },
+          {
+            "value": "145",
+            "label": "Complimentary newspaper in lobby"
+          },
+          {
+            "value": "146",
+            "label": "Complimentary shoeshine"
+          },
+          {
+            "value": "148",
+            "label": "Front desk"
+          },
+          {
+            "value": "149",
+            "label": "Grocery shopping service available"
+          },
+          {
+            "value": "150",
+            "label": "Halal food available"
+          },
+          {
+            "value": "151",
+            "label": "Kosher food available"
+          },
+          {
+            "value": "153",
+            "label": "Managers reception"
+          },
+          {
+            "value": "154",
+            "label": "Medical Facilities Service"
+          },
+          {
+            "value": "162",
+            "label": "Meal plan available"
+          },
+          {
+            "value": "164",
+            "label": "Food and beverage outlets"
+          },
+          {
+            "value": "165",
+            "label": "Lounges / Bars"
+          },
+          {
+            "value": "170",
+            "label": "Concierge lounge"
+          },
+          {
+            "value": "171",
+            "label": "Parking fee managed by hotel"
+          },
+          {
+            "value": "179",
+            "label": "Wireless internet in public areas"
+          },
+          {
+            "value": "181",
+            "label": "Transportation services - local area"
+          },
+          {
+            "value": "186",
+            "label": "Street side parking"
+          },
+          {
+            "value": "189",
+            "label": "Motorcycle parking"
+          },
+          {
+            "value": "191",
+            "label": "Ballroom"
+          },
+          {
+            "value": "192",
+            "label": "Bus parking"
+          },
+          {
+            "value": "193",
+            "label": "Children's play area"
+          },
+          {
+            "value": "194",
+            "label": "Children's nursery"
+          },
+          {
+            "value": "196",
+            "label": "Early check-in"
+          },
+          {
+            "value": "198",
+            "label": "Non-smoking rooms"
+          },
+          {
+            "value": "201",
+            "label": "Baggage hold"
+          },
+          {
+            "value": "203",
+            "label": "Dietician"
+          },
+          {
+            "value": "204",
+            "label": "Late check-out"
+          },
+          {
+            "value": "205",
+            "label": "Pet-sitting services"
+          },
+          {
+            "value": "206",
+            "label": "Prayer mats"
+          },
+          {
+            "value": "208",
+            "label": "Turndown service"
+          },
+          {
+            "value": "211",
+            "label": "Lobby coffee service"
+          },
+          {
+            "value": "213",
+            "label": "Stairwells"
+          },
+          {
+            "value": "214",
+            "label": "Pet amenities available"
+          },
+          {
+            "value": "215",
+            "label": "Exhibition/convention floor"
+          },
+          {
+            "value": "216",
+            "label": "Long term parking"
+          },
+          {
+            "value": "217",
+            "label": "Children not allowed"
+          },
+          {
+            "value": "218",
+            "label": "Children welcome"
+          },
+          {
+            "value": "224",
+            "label": "Pets allowed"
+          },
+          {
+            "value": "226",
+            "label": "Catering services"
+          },
+          {
+            "value": "227",
+            "label": "Complimentary breakfast"
+          },
+          {
+            "value": "228",
+            "label": "Business center"
+          },
+          {
+            "value": "230",
+            "label": "Secured parking"
+          },
+          {
+            "value": "243",
+            "label": "Toilet"
+          },
+          {
+            "value": "247",
+            "label": "Private dining for groups"
+          },
+          {
+            "value": "249",
+            "label": "Carryout breakfast"
+          },
+          {
+            "value": "254",
+            "label": "Connecting rooms"
+          },
+          {
+            "value": "256",
+            "label": "Exterior corridors"
+          },
+          {
+            "value": "260",
+            "label": "Interior corridors"
+          },
+          {
+            "value": "265",
+            "label": "Welcome drink"
+          },
+          {
+            "value": "266",
+            "label": "Boarding pass print-out available"
+          },
+          {
+            "value": "268",
+            "label": "All public areas non-smoking"
+          },
+          {
+            "value": "269",
+            "label": "Meeting rooms"
+          },
+          {
+            "value": "276",
+            "label": "Lobby"
+          },
+          {
+            "value": "278",
+            "label": "Umbrellas"
+          },
+          {
+            "value": "280",
+            "label": "Grocery store"
+          },
+          {
+            "value": "282",
+            "label": "Airport shuttle service"
+          },
+          {
+            "value": "286",
+            "label": "Complimentary wireless internet"
+          },
+          {
+            "value": "287",
+            "label": "Concierge lounge breakfast"
+          },
+          {
+            "value": "288",
+            "label": "Same gender room/floor"
+          },
+          {
+            "value": "292",
+            "label": "Newspaper"
+          },
+          {
+            "value": "298",
+            "label": "Cell phone rental"
+          },
+          {
+            "value": "309",
+            "label": "Welcome gift"
+          },
+          {
+            "value": "312",
+            "label": "Smoke-free property"
+          },
+          {
+            "value": "313",
+            "label": "Water purification system in use"
+          },
+          {
+            "value": "316",
+            "label": "Electric car charging stations"
+          },
+          {
+            "value": "322",
+            "label": "Loading dock"
+          },
+          {
+            "value": "323",
+            "label": "Baby kit"
+          },
+          {
+            "value": "324",
+            "label": "Children's breakfast"
+          },
+          {
+            "value": "325",
+            "label": "Cloakroom service"
+          },
+          {
+            "value": "328",
+            "label": "Late check-in"
+          },
+          {
+            "value": "329",
+            "label": "Limited parking"
+          },
+          {
+            "value": "331",
+            "label": "No parking available"
+          },
+          {
+            "value": "334",
+            "label": "Summer terrace"
+          },
+          {
+            "value": "335",
+            "label": "Winter terrace"
+          },
+          {
+            "value": "336",
+            "label": "Roof terrace"
+          },
+          {
+            "value": "338",
+            "label": "Helicopter service"
+          },
+          {
+            "value": "343",
+            "label": "Guestroom wired internet"
+          },
+          {
+            "value": "344",
+            "label": "Guestroom wireless internet"
+          },
+          {
+            "value": "345",
+            "label": "Fitness Center"
+          }
+        ]
+      },
+      {
+        "code": "LOC",
+        "label": "Location codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Airport"
+          },
+          {
+            "value": "2",
+            "label": "Beach"
+          },
+          {
+            "value": "3",
+            "label": "City"
+          },
+          {
+            "value": "4",
+            "label": "Downtown"
+          },
+          {
+            "value": "5",
+            "label": "East"
+          },
+          {
+            "value": "6",
+            "label": "Expressway"
+          },
+          {
+            "value": "7",
+            "label": "Lake"
+          },
+          {
+            "value": "8",
+            "label": "Mountain"
+          },
+          {
+            "value": "9",
+            "label": "North"
+          },
+          {
+            "value": "10",
+            "label": "Resort"
+          },
+          {
+            "value": "11",
+            "label": "Rural"
+          },
+          {
+            "value": "12",
+            "label": "South"
+          },
+          {
+            "value": "13",
+            "label": "Suburban"
+          },
+          {
+            "value": "14",
+            "label": "West"
+          },
+          {
+            "value": "15",
+            "label": "Beachfront"
+          },
+          {
+            "value": "16",
+            "label": "Oceanfront"
+          },
+          {
+            "value": "17",
+            "label": "Gulf"
+          },
+          {
+            "value": "18",
+            "label": "Business district"
+          },
+          {
+            "value": "19",
+            "label": "Entertainment district"
+          },
+          {
+            "value": "20",
+            "label": "Financial district"
+          },
+          {
+            "value": "21",
+            "label": "Shopping district"
+          },
+          {
+            "value": "22",
+            "label": "Theatre district"
+          },
+          {
+            "value": "23",
+            "label": "Countryside"
+          },
+          {
+            "value": "24",
+            "label": "Bay"
+          },
+          {
+            "value": "25",
+            "label": "Marina"
+          },
+          {
+            "value": "26",
+            "label": "Park"
+          },
+          {
+            "value": "27",
+            "label": "River"
+          },
+          {
+            "value": "28",
+            "label": "Tourist site"
+          },
+          {
+            "value": "29",
+            "label": "North suburb"
+          },
+          {
+            "value": "30",
+            "label": "South suburb"
+          },
+          {
+            "value": "31",
+            "label": "East suburb"
+          },
+          {
+            "value": "32",
+            "label": "West suburb"
+          },
+          {
+            "value": "33",
+            "label": "Waterfront"
+          },
+          {
+            "value": "34",
+            "label": "Ski resort"
+          }
+        ]
+      },
+      {
+        "code": "MRC",
+        "label": "Meeting room amenities",
+        "codes": [
+          {
+            "value": "1",
+            "label": "AV Equip"
+          },
+          {
+            "value": "7",
+            "label": "Catered dinner"
+          },
+          {
+            "value": "8",
+            "label": "Catered lunch"
+          },
+          {
+            "value": "9",
+            "label": "Copier"
+          },
+          {
+            "value": "10",
+            "label": "Decorator"
+          },
+          {
+            "value": "16",
+            "label": "Flip chart w. markers"
+          },
+          {
+            "value": "17",
+            "label": "High speed internet access"
+          },
+          {
+            "value": "22",
+            "label": "LCD projector"
+          },
+          {
+            "value": "25",
+            "label": "Microphone"
+          },
+          {
+            "value": "30",
+            "label": "PA system"
+          },
+          {
+            "value": "31",
+            "label": "Pens / Pencils / Pads"
+          },
+          {
+            "value": "33",
+            "label": "Podium"
+          },
+          {
+            "value": "37",
+            "label": "Projector"
+          },
+          {
+            "value": "39",
+            "label": "Rear screen"
+          },
+          {
+            "value": "41",
+            "label": "Security guards"
+          },
+          {
+            "value": "42",
+            "label": "Separate entrance"
+          },
+          {
+            "value": "44",
+            "label": "Spotlights"
+          },
+          {
+            "value": "52",
+            "label": "Video camera"
+          },
+          {
+            "value": "53",
+            "label": "Video conferencing"
+          },
+          {
+            "value": "58",
+            "label": "Whiteboards"
+          },
+          {
+            "value": "96",
+            "label": "Teleconference"
+          },
+          {
+            "value": "125",
+            "label": "WiFi"
+          },
+          {
+            "value": "126",
+            "label": "Natural daylight"
+          },
+          {
+            "value": "130",
+            "label": "Background music"
+          },
+          {
+            "value": "134",
+            "label": "DVD player"
+          },
+          {
+            "value": "138",
+            "label": "Projection stand"
+          },
+          {
+            "value": "164",
+            "label": "Lectern"
+          },
+          {
+            "value": "180",
+            "label": "Outdoor function space"
+          },
+          {
+            "value": "182",
+            "label": "Banquet service"
+          }
+        ]
+      },
+      {
+        "code": "MRF",
+        "label": "Meeting room format codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Banquet"
+          },
+          {
+            "value": "2",
+            "label": "Classroom"
+          },
+          {
+            "value": "3",
+            "label": "Conference "
+          },
+          {
+            "value": "4",
+            "label": "Round tables"
+          },
+          {
+            "value": "5",
+            "label": "Theatre"
+          },
+          {
+            "value": "6",
+            "label": "U Shape"
+          },
+          {
+            "value": "7",
+            "label": "Reception"
+          },
+          {
+            "value": "8",
+            "label": "Boardroom"
+          },
+          {
+            "value": "15",
+            "label": "Ballroom"
+          },
+          {
+            "value": "16",
+            "label": "Exhibit"
+          },
+          {
+            "value": "46",
+            "label": "Foyer"
+          }
+        ]
+      },
+      {
+        "code": "PCT",
+        "label": "Property class types",
+        "codes": [
+          {
+            "value": "1",
+            "label": "All suite"
+          },
+          {
+            "value": "2",
+            "label": "All-Inclusive resort"
+          },
+          {
+            "value": "3",
+            "label": "Apartment"
+          },
+          {
+            "value": "4",
+            "label": "Bed & breakfast"
+          },
+          {
+            "value": "5",
+            "label": "Cabin or bungalow"
+          },
+          {
+            "value": "6",
+            "label": "Campground"
+          },
+          {
+            "value": "7",
+            "label": "Chalet"
+          },
+          {
+            "value": "9",
+            "label": "Conference center"
+          },
+          {
+            "value": "11",
+            "label": "Corporate business transient"
+          },
+          {
+            "value": "12",
+            "label": "Cruise"
+          },
+          {
+            "value": "13",
+            "label": "Extended stay"
+          },
+          {
+            "value": "14",
+            "label": "Ferry"
+          },
+          {
+            "value": "15",
+            "label": "Guest farm"
+          },
+          {
+            "value": "16",
+            "label": "Guest house"
+          },
+          {
+            "value": "19",
+            "label": "Hostel"
+          },
+          {
+            "value": "20",
+            "label": "Hotel"
+          },
+          {
+            "value": "21",
+            "label": "Inn"
+          },
+          {
+            "value": "22",
+            "label": "Lodge"
+          },
+          {
+            "value": "24",
+            "label": "Meeting/Convention"
+          },
+          {
+            "value": "25",
+            "label": "Mobile-home"
+          },
+          {
+            "value": "26",
+            "label": "Monastery"
+          },
+          {
+            "value": "27",
+            "label": "Motel"
+          },
+          {
+            "value": "28",
+            "label": "Ranch"
+          },
+          {
+            "value": "30",
+            "label": "Resort"
+          },
+          {
+            "value": "31",
+            "label": "Sailing ship"
+          },
+          {
+            "value": "33",
+            "label": "Tent"
+          },
+          {
+            "value": "34",
+            "label": "Furnished house"
+          },
+          {
+            "value": "35",
+            "label": "Villa"
+          },
+          {
+            "value": "36",
+            "label": "Wildlife reserve"
+          },
+          {
+            "value": "37",
+            "label": "Castle"
+          },
+          {
+            "value": "38",
+            "label": "Convention Network Property"
+          },
+          {
+            "value": "39",
+            "label": "Golf"
+          },
+          {
+            "value": "40",
+            "label": "Pension"
+          },
+          {
+            "value": "41",
+            "label": "Ski"
+          },
+          {
+            "value": "42",
+            "label": "Spa"
+          },
+          {
+            "value": "43",
+            "label": "Time share"
+          },
+          {
+            "value": "44",
+            "label": "Boatel"
+          },
+          {
+            "value": "45",
+            "label": "Boutique"
+          },
+          {
+            "value": "47",
+            "label": "Full service"
+          },
+          {
+            "value": "48",
+            "label": "Historical"
+          },
+          {
+            "value": "49",
+            "label": "Limited service"
+          },
+          {
+            "value": "50",
+            "label": "Recreational vehicle park"
+          },
+          {
+            "value": "51",
+            "label": "Charm hotel"
+          },
+          {
+            "value": "53",
+            "label": "Vacation rental"
+          },
+          {
+            "value": "58",
+            "label": "Union"
+          },
+          {
+            "value": "59",
+            "label": "Leisure"
+          },
+          {
+            "value": "60",
+            "label": "Wholesale"
+          },
+          {
+            "value": "61",
+            "label": "Transient"
+          },
+          {
+            "value": "62",
+            "label": "Other"
+          }
+        ]
+      },
+      {
+        "code": "PHY",
+        "label": "Accessibility feature codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Americans with Disabilities Act (ADA) compliance"
+          },
+          {
+            "value": "2",
+            "label": "Audible emergency alarm for sight impaired guest"
+          },
+          {
+            "value": "6",
+            "label": "Complies with Local / State / Federal laws for disabled"
+          },
+          {
+            "value": "10",
+            "label": "Elevators have Braille Instructions"
+          },
+          {
+            "value": "11",
+            "label": "Emergency exit signs in Braille"
+          },
+          {
+            "value": "12",
+            "label": "Emergency info in Braille"
+          },
+          {
+            "value": "13",
+            "label": "Flashing door knocker available "
+          },
+          {
+            "value": "14",
+            "label": "Impairment aids available"
+          },
+          {
+            "value": "28",
+            "label": "Public areas wheelchair accessible"
+          },
+          {
+            "value": "29",
+            "label": "Service animals allowed on property for people with disabilities"
+          },
+          {
+            "value": "32",
+            "label": "Toilet seat in guest rooms for disabled person"
+          },
+          {
+            "value": "33",
+            "label": "Vibrating alarm available"
+          },
+          {
+            "value": "34",
+            "label": "Visual emergency alarm for hearing impaired guest"
+          },
+          {
+            "value": "36",
+            "label": "Wheelchairs available"
+          },
+          {
+            "value": "37",
+            "label": "Which floors have accessible rooms"
+          },
+          {
+            "value": "38",
+            "label": "Grab bars in bathroom"
+          },
+          {
+            "value": "39",
+            "label": "Telephone for hearing impaired"
+          },
+          {
+            "value": "42",
+            "label": "Wheelchair accessible elevators"
+          },
+          {
+            "value": "43",
+            "label": "Hearing impaired services"
+          },
+          {
+            "value": "44",
+            "label": "Bathtub seat"
+          },
+          {
+            "value": "45",
+            "label": "Closed caption TV"
+          },
+          {
+            "value": "46",
+            "label": "Safety bars in shower"
+          },
+          {
+            "value": "47",
+            "label": "Television amplifier"
+          },
+          {
+            "value": "48",
+            "label": "Walk-in shower"
+          },
+          {
+            "value": "49",
+            "label": "Ramp access"
+          },
+          {
+            "value": "50",
+            "label": "Accessible parking"
+          },
+          {
+            "value": "51",
+            "label": "Accessible van parking"
+          },
+          {
+            "value": "52",
+            "label": "Raised toilet seat with grab bars"
+          },
+          {
+            "value": "53",
+            "label": "Bathroom doors open outwards"
+          },
+          {
+            "value": "54",
+            "label": "Accommodations have bath in bedroom"
+          },
+          {
+            "value": "55",
+            "label": "Elevator access to all levels"
+          },
+          {
+            "value": "56",
+            "label": "Elevator near accessible rooms"
+          },
+          {
+            "value": "57",
+            "label": "Emergency cord / button system in bathroom"
+          },
+          {
+            "value": "58",
+            "label": "Emergency cord / button system in bedroom"
+          },
+          {
+            "value": "59",
+            "label": "Emergency instructions in pictorial form"
+          },
+          {
+            "value": "60",
+            "label": "Emergency procedures for people with disabilities"
+          },
+          {
+            "value": "61",
+            "label": "Facilities for people with vision impairment only"
+          },
+          {
+            "value": "62",
+            "label": "Facilities for people with hearing impairment only"
+          },
+          {
+            "value": "63",
+            "label": "Feather free bedding / pillows available"
+          },
+          {
+            "value": "64",
+            "label": "Flat terrain between parking and entrance"
+          },
+          {
+            "value": "65",
+            "label": "Hearing induction loop system installed"
+          },
+          {
+            "value": "66",
+            "label": "Restaurant / bar menus available in Braille"
+          },
+          {
+            "value": "67",
+            "label": "Restaurant / bar menus available in 14pt print"
+          },
+          {
+            "value": "68",
+            "label": "Roll-in shower area with bathroom seat"
+          },
+          {
+            "value": "69",
+            "label": "Service dogs allowed"
+          },
+          {
+            "value": "70",
+            "label": "Staff proficient in sign language"
+          },
+          {
+            "value": "71",
+            "label": "Staff trained in service to disabled guests"
+          },
+          {
+            "value": "72",
+            "label": "Steps / staircases have handrails"
+          },
+          {
+            "value": "73",
+            "label": "Steps / staircases have color markings"
+          },
+          {
+            "value": "74",
+            "label": "Subtitles / closed captions available on TV"
+          },
+          {
+            "value": "75",
+            "label": "Tactile / 14pt print signage throughout hotel"
+          },
+          {
+            "value": "76",
+            "label": "Vibrating pillows available"
+          },
+          {
+            "value": "102",
+            "label": "Accessible baths"
+          },
+          {
+            "value": "103",
+            "label": "Braille / large print literature"
+          },
+          {
+            "value": "104",
+            "label": "Adapted room doors"
+          },
+          {
+            "value": "105",
+            "label": "Bedroom wheelchair access"
+          },
+          {
+            "value": "106",
+            "label": "Special needs menus"
+          },
+          {
+            "value": "107",
+            "label": "Wide entrance"
+          },
+          {
+            "value": "108",
+            "label": "Wide corridors"
+          },
+          {
+            "value": "109",
+            "label": "Wide restaurant entrance"
+          },
+          {
+            "value": "110",
+            "label": "Roll-in shower available"
+          },
+          {
+            "value": "111",
+            "label": "Lever handles on guest room doors"
+          },
+          {
+            "value": "112",
+            "label": "Lowered night guards on guest room doors"
+          },
+          {
+            "value": "113",
+            "label": "Lowered electrical outlets"
+          },
+          {
+            "value": "114",
+            "label": "Bathtub grab bars"
+          },
+          {
+            "value": "115",
+            "label": "Adjustable height hand-held shower wand"
+          },
+          {
+            "value": "116",
+            "label": "TTY/TTD compatible"
+          },
+          {
+            "value": "129",
+            "label": "Hotel entrance is accessible"
+          },
+          {
+            "value": "130",
+            "label": "Route from accessible public entrance to registration area is accessible"
+          },
+          {
+            "value": "131",
+            "label": "Guest rooms and access routes are accessible"
+          },
+          {
+            "value": "138",
+            "label": "Accessible rooms"
+          },
+          {
+            "value": "139",
+            "label": "Registration desk is wheelchair accessible"
+          },
+          {
+            "value": "140",
+            "label": "Concierge desk is wheelchair accessible"
+          },
+          {
+            "value": "141",
+            "label": "Hotel restaurant is wheelchair accessible"
+          },
+          {
+            "value": "142",
+            "label": "Exercise facility is wheelchair accessible"
+          },
+          {
+            "value": "143",
+            "label": "Pool is wheelchair accessible"
+          },
+          {
+            "value": "144",
+            "label": "Business center is wheelchair accessible"
+          },
+          {
+            "value": "145",
+            "label": "Accessible self parking available"
+          },
+          {
+            "value": "146",
+            "label": "Van accessible parking in self parking"
+          },
+          {
+            "value": "147",
+            "label": "Complementary accessible transportation with advanced notice"
+          },
+          {
+            "value": "148",
+            "label": "Portable bathtub seats"
+          },
+          {
+            "value": "149",
+            "label": "Assistive listening devices for meetings upon request"
+          }
+        ]
+      },
+      {
+        "code": "PIC",
+        "label": "Picture category codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Exterior view"
+          },
+          {
+            "value": "2",
+            "label": "Lobby view"
+          },
+          {
+            "value": "3",
+            "label": "Pool view"
+          },
+          {
+            "value": "4",
+            "label": "Restaurant"
+          },
+          {
+            "value": "5",
+            "label": "Health club"
+          },
+          {
+            "value": "6",
+            "label": "Guest room"
+          },
+          {
+            "value": "7",
+            "label": "Suite"
+          },
+          {
+            "value": "8",
+            "label": "Meeting room"
+          },
+          {
+            "value": "9",
+            "label": "Ballroom "
+          },
+          {
+            "value": "10",
+            "label": "Golf course"
+          },
+          {
+            "value": "11",
+            "label": "Beach"
+          },
+          {
+            "value": "12",
+            "label": "Spa"
+          },
+          {
+            "value": "13",
+            "label": "Bar/Lounge"
+          },
+          {
+            "value": "14",
+            "label": "Recreational facility"
+          },
+          {
+            "value": "15",
+            "label": "Logo"
+          },
+          {
+            "value": "16",
+            "label": "Basics"
+          },
+          {
+            "value": "17",
+            "label": "Map"
+          },
+          {
+            "value": "18",
+            "label": "Promotional"
+          },
+          {
+            "value": "19",
+            "label": "Hot news"
+          },
+          {
+            "value": "20",
+            "label": "Miscellaneous"
+          },
+          {
+            "value": "21",
+            "label": "Guest room amenity"
+          },
+          {
+            "value": "22",
+            "label": "Property amenity"
+          },
+          {
+            "value": "23",
+            "label": "Business center"
+          }
+        ]
+      },
+      {
+        "code": "PRX",
+        "label": "Proximity codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "On premises"
+          },
+          {
+            "value": "2",
+            "label": "Off premises"
+          },
+          {
+            "value": "3",
+            "label": "Nearby"
+          },
+          {
+            "value": "4",
+            "label": "Not available"
+          },
+          {
+            "value": "5",
+            "label": "On & Off premises"
+          }
+        ]
+      },
+      {
+        "code": "REC",
+        "label": "Recreation type codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Driving range"
+          },
+          {
+            "value": "2",
+            "label": "Golf course total yardage"
+          },
+          {
+            "value": "3",
+            "label": "Number of holes"
+          },
+          {
+            "value": "4",
+            "label": "Par for course"
+          },
+          {
+            "value": "5",
+            "label": "Putting green"
+          },
+          {
+            "value": "6",
+            "label": "Available equipment"
+          },
+          {
+            "value": "7",
+            "label": "Cardiovascular equipment"
+          },
+          {
+            "value": "8",
+            "label": "Free weights"
+          },
+          {
+            "value": "9",
+            "label": "Separate mens and women's lockers"
+          },
+          {
+            "value": "10",
+            "label": "Separate mens and women's steam rooms"
+          },
+          {
+            "value": "11",
+            "label": "Boot warmers"
+          },
+          {
+            "value": "12",
+            "label": "Ski lockers"
+          },
+          {
+            "value": "13",
+            "label": "Snow boarding"
+          },
+          {
+            "value": "14",
+            "label": "Snow mobiling"
+          },
+          {
+            "value": "15",
+            "label": "Body scrub"
+          },
+          {
+            "value": "16",
+            "label": "Body wrap"
+          },
+          {
+            "value": "17",
+            "label": "Facials"
+          },
+          {
+            "value": "18",
+            "label": "Fitness counseling"
+          },
+          {
+            "value": "19",
+            "label": "Foot bath"
+          },
+          {
+            "value": "20",
+            "label": "Lap pool"
+          },
+          {
+            "value": "21",
+            "label": "Manicures/pedicures"
+          },
+          {
+            "value": "22",
+            "label": "Massages"
+          },
+          {
+            "value": "23",
+            "label": "Massage lessons"
+          },
+          {
+            "value": "24",
+            "label": "Paraffin hand treatment"
+          },
+          {
+            "value": "25",
+            "label": "Plunge pools"
+          },
+          {
+            "value": "26",
+            "label": "Spa restaurant"
+          },
+          {
+            "value": "27",
+            "label": "Steam room"
+          },
+          {
+            "value": "28",
+            "label": "Therapy baths"
+          },
+          {
+            "value": "29",
+            "label": "Waxing"
+          },
+          {
+            "value": "30",
+            "label": "Heated pool"
+          },
+          {
+            "value": "31",
+            "label": "Lifeguard on duty"
+          },
+          {
+            "value": "32",
+            "label": "Pool depth"
+          },
+          {
+            "value": "33",
+            "label": "Whirlpool open year round"
+          },
+          {
+            "value": "34",
+            "label": "Appointment required"
+          },
+          {
+            "value": "35",
+            "label": "Classes available"
+          },
+          {
+            "value": "36",
+            "label": "Facility type"
+          },
+          {
+            "value": "37",
+            "label": "Guest privileges available"
+          },
+          {
+            "value": "38",
+            "label": "Lessons available"
+          },
+          {
+            "value": "39",
+            "label": "Rental information"
+          },
+          {
+            "value": "40",
+            "label": "Restricted age for children without adult supervision"
+          },
+          {
+            "value": "41",
+            "label": "Services available"
+          },
+          {
+            "value": "42",
+            "label": "Teen programs"
+          },
+          {
+            "value": "43",
+            "label": "Towels available"
+          },
+          {
+            "value": "44",
+            "label": "Children's program"
+          },
+          {
+            "value": "45",
+            "label": "Fitness center equipment replacement date"
+          },
+          {
+            "value": "46",
+            "label": "Private"
+          },
+          {
+            "value": "47",
+            "label": "Public"
+          },
+          {
+            "value": "48",
+            "label": "Slope"
+          },
+          {
+            "value": "49",
+            "label": "Rowing machine"
+          },
+          {
+            "value": "50",
+            "label": "Stair stepper"
+          },
+          {
+            "value": "51",
+            "label": "Stationary bike"
+          },
+          {
+            "value": "52",
+            "label": "Treadmill"
+          },
+          {
+            "value": "53",
+            "label": "Golf location"
+          },
+          {
+            "value": "54",
+            "label": "Greens fees"
+          },
+          {
+            "value": "55",
+            "label": "Ellipticals "
+          },
+          {
+            "value": "56",
+            "label": "Complimentary water available "
+          },
+          {
+            "value": "57",
+            "label": "Fresh whole fruit available "
+          },
+          {
+            "value": "58",
+            "label": "Strength equipment"
+          },
+          {
+            "value": "59",
+            "label": "Weight machine"
+          },
+          {
+            "value": "60",
+            "label": "Core/stability training equipment"
+          },
+          {
+            "value": "61",
+            "label": "Sauna room "
+          },
+          {
+            "value": "62",
+            "label": "Spa treatment rooms"
+          },
+          {
+            "value": "63",
+            "label": "Golf school instruction"
+          },
+          {
+            "value": "64",
+            "label": "Clubhouse"
+          },
+          {
+            "value": "65",
+            "label": "Clubhouse restaurant"
+          },
+          {
+            "value": "66",
+            "label": "Golf shop"
+          },
+          {
+            "value": "67",
+            "label": "Men's services"
+          },
+          {
+            "value": "68",
+            "label": "Scalp and hair treatments"
+          },
+          {
+            "value": "69",
+            "label": "Eye treatments"
+          },
+          {
+            "value": "70",
+            "label": "Lip treatments"
+          },
+          {
+            "value": "71",
+            "label": "Ayurvedic treatments"
+          },
+          {
+            "value": "72",
+            "label": "Makeup services"
+          },
+          {
+            "value": "73",
+            "label": "Separate men's and women's lounges"
+          },
+          {
+            "value": "74",
+            "label": "In-suite massage"
+          },
+          {
+            "value": "75",
+            "label": "Couple's massage"
+          },
+          {
+            "value": "76",
+            "label": "Kid's services"
+          },
+          {
+            "value": "77",
+            "label": "Tennis clinic"
+          },
+          {
+            "value": "78",
+            "label": "Tennis ball machine rental"
+          },
+          {
+            "value": "79",
+            "label": "Tennis racquet rental"
+          },
+          {
+            "value": "80",
+            "label": "Beach umbrella"
+          },
+          {
+            "value": "81",
+            "label": "Beach cabanas"
+          },
+          {
+            "value": "82",
+            "label": "Stretching"
+          },
+          {
+            "value": "83",
+            "label": "Hiking routes"
+          },
+          {
+            "value": "84",
+            "label": "Diving center"
+          },
+          {
+            "value": "85",
+            "label": "Beauty cabin"
+          },
+          {
+            "value": "86",
+            "label": "Body treatments"
+          },
+          {
+            "value": "87",
+            "label": "Medical cabin"
+          },
+          {
+            "value": "88",
+            "label": "Pedicure"
+          },
+          {
+            "value": "89",
+            "label": "Respiratory therapy area"
+          },
+          {
+            "value": "90",
+            "label": "Showers"
+          },
+          {
+            "value": "91",
+            "label": "Shop"
+          },
+          {
+            "value": "92",
+            "label": "Swimming pool"
+          },
+          {
+            "value": "93",
+            "label": "Whirlpool"
+          },
+          {
+            "value": "94",
+            "label": "Locker room"
+          },
+          {
+            "value": "95",
+            "label": "Fitness classes"
+          },
+          {
+            "value": "96",
+            "label": "Sports trainer"
+          },
+          {
+            "value": "97",
+            "label": "Thalassotherapy"
+          }
+        ]
+      },
+      {
+        "code": "REF",
+        "label": "Reference point category codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Airport"
+          },
+          {
+            "value": "2",
+            "label": "Amusement park"
+          },
+          {
+            "value": "3",
+            "label": "Arena"
+          },
+          {
+            "value": "4",
+            "label": "Bar"
+          },
+          {
+            "value": "5",
+            "label": "Bay"
+          },
+          {
+            "value": "6",
+            "label": "Beach"
+          },
+          {
+            "value": "7",
+            "label": "Boat dock"
+          },
+          {
+            "value": "8",
+            "label": "Bus station"
+          },
+          {
+            "value": "9",
+            "label": "Church"
+          },
+          {
+            "value": "10",
+            "label": "City center"
+          },
+          {
+            "value": "11",
+            "label": "Corporation"
+          },
+          {
+            "value": "12",
+            "label": "Educational institution"
+          },
+          {
+            "value": "13",
+            "label": "Ferry station"
+          },
+          {
+            "value": "14",
+            "label": "Financial district"
+          },
+          {
+            "value": "15",
+            "label": "Financial institution"
+          },
+          {
+            "value": "16",
+            "label": "Lake"
+          },
+          {
+            "value": "17",
+            "label": "Landmark"
+          },
+          {
+            "value": "18",
+            "label": "Library"
+          },
+          {
+            "value": "19",
+            "label": "Marina"
+          },
+          {
+            "value": "20",
+            "label": "Market"
+          },
+          {
+            "value": "21",
+            "label": "Medical facility"
+          },
+          {
+            "value": "22",
+            "label": "Metro/subway station "
+          },
+          {
+            "value": "23",
+            "label": "Monument"
+          },
+          {
+            "value": "24",
+            "label": "Museum"
+          },
+          {
+            "value": "25",
+            "label": "Park"
+          },
+          {
+            "value": "26",
+            "label": "Racetrack"
+          },
+          {
+            "value": "27",
+            "label": "Restaurant"
+          },
+          {
+            "value": "28",
+            "label": "River"
+          },
+          {
+            "value": "29",
+            "label": "School"
+          },
+          {
+            "value": "30",
+            "label": "Shopping center"
+          },
+          {
+            "value": "31",
+            "label": "Sports facility"
+          },
+          {
+            "value": "32",
+            "label": "Synagogue"
+          },
+          {
+            "value": "33",
+            "label": "Town center"
+          },
+          {
+            "value": "34",
+            "label": "Train station"
+          },
+          {
+            "value": "35",
+            "label": "University"
+          },
+          {
+            "value": "36",
+            "label": "Zoo"
+          },
+          {
+            "value": "37",
+            "label": "Local area"
+          },
+          {
+            "value": "38",
+            "label": "Point of interest"
+          }
+        ]
+      },
+      {
+        "code": "RES",
+        "label": "Restaurant category codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "All purpose"
+          },
+          {
+            "value": "2",
+            "label": "Beverage"
+          },
+          {
+            "value": "3",
+            "label": "Buffet"
+          },
+          {
+            "value": "4",
+            "label": "Cafe"
+          },
+          {
+            "value": "5",
+            "label": "Cafeteria"
+          },
+          {
+            "value": "6",
+            "label": "Casual"
+          },
+          {
+            "value": "7",
+            "label": "Family"
+          },
+          {
+            "value": "8",
+            "label": "Fast food"
+          },
+          {
+            "value": "9",
+            "label": "Fine dining"
+          },
+          {
+            "value": "10",
+            "label": "Kiosk"
+          },
+          {
+            "value": "11",
+            "label": "Take out"
+          },
+          {
+            "value": "12",
+            "label": "Upscale"
+          },
+          {
+            "value": "13",
+            "label": "Bar/lounge"
+          },
+          {
+            "value": "14",
+            "label": "Brasserie"
+          },
+          {
+            "value": "15",
+            "label": "Coffee bar"
+          },
+          {
+            "value": "16",
+            "label": "Snack bar"
+          },
+          {
+            "value": "17",
+            "label": "Full service"
+          },
+          {
+            "value": "18",
+            "label": "Pub"
+          },
+          {
+            "value": "19",
+            "label": "Deli"
+          },
+          {
+            "value": "20",
+            "label": "Private dining"
+          },
+          {
+            "value": "21",
+            "label": "Sports bar"
+          },
+          {
+            "value": "22",
+            "label": "Piano bar"
+          },
+          {
+            "value": "23",
+            "label": "Outdoor bar/café"
+          },
+          {
+            "value": "24",
+            "label": "Beer garden"
+          },
+          {
+            "value": "25",
+            "label": "Beach bar"
+          },
+          {
+            "value": "26",
+            "label": "Tapas bar"
+          }
+        ]
+      },
+      {
+        "code": "RLT",
+        "label": "Room location types",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Away from elevator"
+          },
+          {
+            "value": "2",
+            "label": "Back of building"
+          },
+          {
+            "value": "3",
+            "label": "Bottom floor"
+          },
+          {
+            "value": "4",
+            "label": "Corner facing"
+          },
+          {
+            "value": "5",
+            "label": "Facing east"
+          },
+          {
+            "value": "7",
+            "label": "Front of building"
+          },
+          {
+            "value": "8",
+            "label": "High floor"
+          },
+          {
+            "value": "9",
+            "label": "Low floor"
+          },
+          {
+            "value": "10",
+            "label": "Near elevator"
+          },
+          {
+            "value": "11",
+            "label": "Facing north"
+          },
+          {
+            "value": "12",
+            "label": "Facing south"
+          },
+          {
+            "value": "13",
+            "label": "Top floor"
+          },
+          {
+            "value": "14",
+            "label": "Facing west"
+          },
+          {
+            "value": "15",
+            "label": "Concierge floor"
+          },
+          {
+            "value": "16",
+            "label": "First floor"
+          },
+          {
+            "value": "17",
+            "label": "Ground floor"
+          },
+          {
+            "value": "18",
+            "label": "Lobby level"
+          },
+          {
+            "value": "19",
+            "label": "Poolside"
+          },
+          {
+            "value": "20",
+            "label": "A quiet room"
+          },
+          {
+            "value": "21",
+            "label": "Tower room"
+          },
+          {
+            "value": "22",
+            "label": "Wing room"
+          },
+          {
+            "value": "23",
+            "label": "Main building"
+          },
+          {
+            "value": "24",
+            "label": "Near stairway"
+          },
+          {
+            "value": "25",
+            "label": "Executive floor"
+          },
+          {
+            "value": "28",
+            "label": "Annex room"
+          },
+          {
+            "value": "1000",
+            "label": "Various locations"
+          }
+        ]
+      },
+      {
+        "code": "RMA",
+        "label": "Room type amenities",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Adjoining rooms"
+          },
+          {
+            "value": "2",
+            "label": "Air conditioning"
+          },
+          {
+            "value": "3",
+            "label": "Alarm clock"
+          },
+          {
+            "value": "4",
+            "label": "News channel"
+          },
+          {
+            "value": "5",
+            "label": "AM/FM radio"
+          },
+          {
+            "value": "6",
+            "label": "Baby monitor"
+          },
+          {
+            "value": "7",
+            "label": "Balcony"
+          },
+          {
+            "value": "8",
+            "label": "BBQ grill"
+          },
+          {
+            "value": "9",
+            "label": "Jetted tub"
+          },
+          {
+            "value": "10",
+            "label": "Bathrobe"
+          },
+          {
+            "value": "11",
+            "label": "Bathroom items"
+          },
+          {
+            "value": "12",
+            "label": "Bathroom phone"
+          },
+          {
+            "value": "13",
+            "label": "Bathtub"
+          },
+          {
+            "value": "14",
+            "label": "Bathtub only"
+          },
+          {
+            "value": "15",
+            "label": "Tub/shower combo"
+          },
+          {
+            "value": "16",
+            "label": "Bidet"
+          },
+          {
+            "value": "17",
+            "label": "Bottled water"
+          },
+          {
+            "value": "18",
+            "label": "Cable TV"
+          },
+          {
+            "value": "19",
+            "label": "Coffee/tea maker"
+          },
+          {
+            "value": "20",
+            "label": "Color TV"
+          },
+          {
+            "value": "21",
+            "label": "Computer"
+          },
+          {
+            "value": "22",
+            "label": "Connecting rooms"
+          },
+          {
+            "value": "23",
+            "label": "Voltage adapters"
+          },
+          {
+            "value": "24",
+            "label": "Copier"
+          },
+          {
+            "value": "25",
+            "label": "Cordless phone"
+          },
+          {
+            "value": "26",
+            "label": "Crib"
+          },
+          {
+            "value": "27",
+            "label": "Data port"
+          },
+          {
+            "value": "28",
+            "label": "Desk"
+          },
+          {
+            "value": "29",
+            "label": "Desk lamp"
+          },
+          {
+            "value": "30",
+            "label": "Dining guide"
+          },
+          {
+            "value": "31",
+            "label": "Direct-dial phone"
+          },
+          {
+            "value": "32",
+            "label": "Dishwasher"
+          },
+          {
+            "value": "33",
+            "label": "Double beds"
+          },
+          {
+            "value": "34",
+            "label": "Dual voltage outlet"
+          },
+          {
+            "value": "35",
+            "label": "Voltage"
+          },
+          {
+            "value": "36",
+            "label": "Ergonomic chair"
+          },
+          {
+            "value": "37",
+            "label": "Long phone cord"
+          },
+          {
+            "value": "38",
+            "label": "Fax"
+          },
+          {
+            "value": "39",
+            "label": "Fire alarm"
+          },
+          {
+            "value": "40",
+            "label": "Fire alarm with light"
+          },
+          {
+            "value": "41",
+            "label": "Fireplace"
+          },
+          {
+            "value": "42",
+            "label": "Free toll calls"
+          },
+          {
+            "value": "43",
+            "label": "Free calls"
+          },
+          {
+            "value": "44",
+            "label": "Free credit calls"
+          },
+          {
+            "value": "45",
+            "label": "Free local calls"
+          },
+          {
+            "value": "46",
+            "label": "Free movies"
+          },
+          {
+            "value": "47",
+            "label": "Full kitchen"
+          },
+          {
+            "value": "48",
+            "label": "Bathroom grab bars"
+          },
+          {
+            "value": "49",
+            "label": "Grecian tub"
+          },
+          {
+            "value": "50",
+            "label": "Hairdryer"
+          },
+          {
+            "value": "51",
+            "label": "High-speed internet"
+          },
+          {
+            "value": "52",
+            "label": "Web TV"
+          },
+          {
+            "value": "53",
+            "label": "International dialing"
+          },
+          {
+            "value": "54",
+            "label": "Internet access"
+          },
+          {
+            "value": "55",
+            "label": "Iron"
+          },
+          {
+            "value": "56",
+            "label": "Ironing board"
+          },
+          {
+            "value": "57",
+            "label": "Whirlpool"
+          },
+          {
+            "value": "58",
+            "label": "King bed"
+          },
+          {
+            "value": "59",
+            "label": "Kitchen"
+          },
+          {
+            "value": "60",
+            "label": "Kitchen supplies"
+          },
+          {
+            "value": "61",
+            "label": "Kitchenette"
+          },
+          {
+            "value": "62",
+            "label": "Knock light"
+          },
+          {
+            "value": "63",
+            "label": "Laptop"
+          },
+          {
+            "value": "64",
+            "label": "Large desk"
+          },
+          {
+            "value": "65",
+            "label": "Work area"
+          },
+          {
+            "value": "66",
+            "label": "Laundry basket"
+          },
+          {
+            "value": "67",
+            "label": "Loft"
+          },
+          {
+            "value": "68",
+            "label": "Microwave"
+          },
+          {
+            "value": "69",
+            "label": "Minibar"
+          },
+          {
+            "value": "70",
+            "label": "Modem"
+          },
+          {
+            "value": "71",
+            "label": "Modem jack"
+          },
+          {
+            "value": "72",
+            "label": "Multi-line phone"
+          },
+          {
+            "value": "73",
+            "label": "Newspaper"
+          },
+          {
+            "value": "74",
+            "label": "Non-smoking"
+          },
+          {
+            "value": "75",
+            "label": "Notepad"
+          },
+          {
+            "value": "76",
+            "label": "Office supplies"
+          },
+          {
+            "value": "77",
+            "label": "Oven"
+          },
+          {
+            "value": "78",
+            "label": "Pay-per-view"
+          },
+          {
+            "value": "79",
+            "label": "Pen"
+          },
+          {
+            "value": "80",
+            "label": "Bathroom phone"
+          },
+          {
+            "value": "81",
+            "label": "Plates & bowls"
+          },
+          {
+            "value": "82",
+            "label": "Pots & pans"
+          },
+          {
+            "value": "83",
+            "label": "Prayer mat"
+          },
+          {
+            "value": "84",
+            "label": "Printer"
+          },
+          {
+            "value": "85",
+            "label": "Private bathroom"
+          },
+          {
+            "value": "86",
+            "label": "Queen bed"
+          },
+          {
+            "value": "87",
+            "label": "Recliner"
+          },
+          {
+            "value": "88",
+            "label": "Refrigerator"
+          },
+          {
+            "value": "89",
+            "label": "Fridge with ice maker"
+          },
+          {
+            "value": "90",
+            "label": "Remote TV"
+          },
+          {
+            "value": "91",
+            "label": "Rollaway bed"
+          },
+          {
+            "value": "92",
+            "label": "Safe"
+          },
+          {
+            "value": "93",
+            "label": "Scanner"
+          },
+          {
+            "value": "94",
+            "label": "Closet"
+          },
+          {
+            "value": "95",
+            "label": "Separate modem line"
+          },
+          {
+            "value": "96",
+            "label": "Shoe polisher"
+          },
+          {
+            "value": "97",
+            "label": "Shower only"
+          },
+          {
+            "value": "98",
+            "label": "Utensils"
+          },
+          {
+            "value": "99",
+            "label": "Sitting area"
+          },
+          {
+            "value": "100",
+            "label": "Smoke detectors"
+          },
+          {
+            "value": "101",
+            "label": "Smoking"
+          },
+          {
+            "value": "102",
+            "label": "Sofa bed"
+          },
+          {
+            "value": "103",
+            "label": "Speakerphone"
+          },
+          {
+            "value": "104",
+            "label": "Stereo"
+          },
+          {
+            "value": "105",
+            "label": "Stove"
+          },
+          {
+            "value": "106",
+            "label": "Tape recorder"
+          },
+          {
+            "value": "107",
+            "label": "Phone"
+          },
+          {
+            "value": "108",
+            "label": "Hearing-impaired phone"
+          },
+          {
+            "value": "109",
+            "label": "Message light phone"
+          },
+          {
+            "value": "110",
+            "label": "Toaster oven"
+          },
+          {
+            "value": "111",
+            "label": "Pant press"
+          },
+          {
+            "value": "112",
+            "label": "Turndown service"
+          },
+          {
+            "value": "113",
+            "label": "Twin bed"
+          },
+          {
+            "value": "114",
+            "label": "Vaulted ceiling"
+          },
+          {
+            "value": "115",
+            "label": "VCR movies"
+          },
+          {
+            "value": "116",
+            "label": "VCR"
+          },
+          {
+            "value": "117",
+            "label": "Video games"
+          },
+          {
+            "value": "118",
+            "label": "Voicemail"
+          },
+          {
+            "value": "119",
+            "label": "Wake-up calls"
+          },
+          {
+            "value": "120",
+            "label": "Toilet"
+          },
+          {
+            "value": "121",
+            "label": "Water purifier"
+          },
+          {
+            "value": "122",
+            "label": "Wet bar"
+          },
+          {
+            "value": "123",
+            "label": "Wi-Fi"
+          },
+          {
+            "value": "124",
+            "label": "Wireless keyboard"
+          },
+          {
+            "value": "125",
+            "label": "PC phone adapter"
+          },
+          {
+            "value": "126",
+            "label": "Room-controlled AC"
+          },
+          {
+            "value": "127",
+            "label": "Separate tub/whirlpool"
+          },
+          {
+            "value": "128",
+            "label": "Phone data port"
+          },
+          {
+            "value": "129",
+            "label": "CD player"
+          },
+          {
+            "value": "130",
+            "label": "Free local calls limit"
+          },
+          {
+            "value": "131",
+            "label": "Extra rollaway fee"
+          },
+          {
+            "value": "132",
+            "label": "Down pillows"
+          },
+          {
+            "value": "133",
+            "label": "Desk with outlet"
+          },
+          {
+            "value": "134",
+            "label": "ESPN"
+          },
+          {
+            "value": "135",
+            "label": "Foam pillows"
+          },
+          {
+            "value": "136",
+            "label": "HBO"
+          },
+          {
+            "value": "137",
+            "label": "High ceilings"
+          },
+          {
+            "value": "138",
+            "label": "Marble bathroom"
+          },
+          {
+            "value": "139",
+            "label": "Movie channels list"
+          },
+          {
+            "value": "140",
+            "label": "Pets allowed"
+          },
+          {
+            "value": "141",
+            "label": "Oversized tub"
+          },
+          {
+            "value": "142",
+            "label": "Shower"
+          },
+          {
+            "value": "143",
+            "label": "In-room sink"
+          },
+          {
+            "value": "144",
+            "label": "Soundproof room"
+          },
+          {
+            "value": "145",
+            "label": "Storage space"
+          },
+          {
+            "value": "146",
+            "label": "Table & chairs"
+          },
+          {
+            "value": "147",
+            "label": "Two-line phone"
+          },
+          {
+            "value": "148",
+            "label": "Walk-in closet"
+          },
+          {
+            "value": "149",
+            "label": "Washer/dryer"
+          },
+          {
+            "value": "150",
+            "label": "Scale"
+          },
+          {
+            "value": "151",
+            "label": "Welcome gift"
+          },
+          {
+            "value": "152",
+            "label": "Spare outlet at desk"
+          },
+          {
+            "value": "153",
+            "label": "Non-refundable pet fee"
+          },
+          {
+            "value": "154",
+            "label": "Refundable pet deposit"
+          },
+          {
+            "value": "155",
+            "label": "Separate tub/shower"
+          },
+          {
+            "value": "156",
+            "label": "Room entrance type"
+          },
+          {
+            "value": "157",
+            "label": "Ceiling fan"
+          },
+          {
+            "value": "158",
+            "label": "CNN"
+          },
+          {
+            "value": "159",
+            "label": "Power adapters"
+          },
+          {
+            "value": "160",
+            "label": "Buffet breakfast"
+          },
+          {
+            "value": "161",
+            "label": "Accessible room"
+          },
+          {
+            "value": "162",
+            "label": "In-room closet"
+          },
+          {
+            "value": "163",
+            "label": "DVD player"
+          },
+          {
+            "value": "164",
+            "label": "Mini fridge"
+          },
+          {
+            "value": "165",
+            "label": "Separate billing phone"
+          },
+          {
+            "value": "166",
+            "label": "Self-controlled heat/AC"
+          },
+          {
+            "value": "167",
+            "label": "Toaster"
+          },
+          {
+            "value": "168",
+            "label": "Analog port"
+          },
+          {
+            "value": "169",
+            "label": "Collect calls"
+          },
+          {
+            "value": "170",
+            "label": "International calls"
+          },
+          {
+            "value": "171",
+            "label": "Carrier access"
+          },
+          {
+            "value": "172",
+            "label": "Interstate calls"
+          },
+          {
+            "value": "173",
+            "label": "Intrastate calls"
+          },
+          {
+            "value": "174",
+            "label": "Local calls"
+          },
+          {
+            "value": "175",
+            "label": "Long distance calls"
+          },
+          {
+            "value": "176",
+            "label": "Operator-assisted calls"
+          },
+          {
+            "value": "177",
+            "label": "Credit card calls"
+          },
+          {
+            "value": "178",
+            "label": "Calling card calls"
+          },
+          {
+            "value": "179",
+            "label": "Toll-free calls"
+          },
+          {
+            "value": "180",
+            "label": "Universal adapters"
+          },
+          {
+            "value": "181",
+            "label": "Bathtub seat"
+          },
+          {
+            "value": "182",
+            "label": "Canopy bed"
+          },
+          {
+            "value": "183",
+            "label": "Cups/glasses"
+          },
+          {
+            "value": "184",
+            "label": "Entertainment center"
+          },
+          {
+            "value": "185",
+            "label": "Family room"
+          },
+          {
+            "value": "186",
+            "label": "Hypoallergenic bed"
+          },
+          {
+            "value": "187",
+            "label": "Hypoallergenic pillows"
+          },
+          {
+            "value": "188",
+            "label": "Lamp"
+          },
+          {
+            "value": "189",
+            "label": "Breakfast included"
+          },
+          {
+            "value": "190",
+            "label": "Continental breakfast"
+          },
+          {
+            "value": "191",
+            "label": "Dinner included"
+          },
+          {
+            "value": "192",
+            "label": "Lunch included"
+          },
+          {
+            "value": "193",
+            "label": "Shared bathroom"
+          },
+          {
+            "value": "194",
+            "label": "TTY phone"
+          },
+          {
+            "value": "195",
+            "label": "Water bed"
+          },
+          {
+            "value": "196",
+            "label": "Extra adult fee"
+          },
+          {
+            "value": "197",
+            "label": "Extra child fee"
+          },
+          {
+            "value": "198",
+            "label": "Child rollaway fee"
+          },
+          {
+            "value": "199",
+            "label": "American breakfast"
+          },
+          {
+            "value": "200",
+            "label": "Futon"
+          },
+          {
+            "value": "201",
+            "label": "Murphy bed"
+          },
+          {
+            "value": "202",
+            "label": "Tatami mats"
+          },
+          {
+            "value": "203",
+            "label": "Single bed"
+          },
+          {
+            "value": "204",
+            "label": "Annex room"
+          },
+          {
+            "value": "205",
+            "label": "Free newspaper"
+          },
+          {
+            "value": "206",
+            "label": "Honeymoon suite"
+          },
+          {
+            "value": "207",
+            "label": "Free high-speed internet"
+          },
+          {
+            "value": "208",
+            "label": "Maid service"
+          },
+          {
+            "value": "209",
+            "label": "PC hookup"
+          },
+          {
+            "value": "210",
+            "label": "Satellite TV"
+          },
+          {
+            "value": "211",
+            "label": "VIP rooms"
+          },
+          {
+            "value": "212",
+            "label": "Phone charger"
+          },
+          {
+            "value": "213",
+            "label": "DVR"
+          },
+          {
+            "value": "214",
+            "label": "iPod dock"
+          },
+          {
+            "value": "215",
+            "label": "Media center"
+          },
+          {
+            "value": "216",
+            "label": "Plug panel"
+          },
+          {
+            "value": "217",
+            "label": "Satellite radio"
+          },
+          {
+            "value": "218",
+            "label": "On-demand video"
+          },
+          {
+            "value": "219",
+            "label": "Exterior corridors"
+          },
+          {
+            "value": "220",
+            "label": "Gulf view"
+          },
+          {
+            "value": "221",
+            "label": "Accessible room"
+          },
+          {
+            "value": "222",
+            "label": "Interior corridors"
+          },
+          {
+            "value": "223",
+            "label": "Mountain view"
+          },
+          {
+            "value": "224",
+            "label": "Ocean view"
+          },
+          {
+            "value": "225",
+            "label": "Internet fee"
+          },
+          {
+            "value": "226",
+            "label": "Wi-Fi fee"
+          },
+          {
+            "value": "227",
+            "label": "Premium movies"
+          },
+          {
+            "value": "228",
+            "label": "Slippers"
+          },
+          {
+            "value": "229",
+            "label": "Welcome kit"
+          },
+          {
+            "value": "230",
+            "label": "Desk chair"
+          },
+          {
+            "value": "231",
+            "label": "Pillow-top mattress"
+          },
+          {
+            "value": "232",
+            "label": "Feather bed"
+          },
+          {
+            "value": "233",
+            "label": "Duvet"
+          },
+          {
+            "value": "234",
+            "label": "Luxury linens"
+          },
+          {
+            "value": "235",
+            "label": "International channels"
+          },
+          {
+            "value": "236",
+            "label": "Pantry"
+          },
+          {
+            "value": "237",
+            "label": "Dishwashing supplies"
+          },
+          {
+            "value": "238",
+            "label": "Double vanity"
+          },
+          {
+            "value": "239",
+            "label": "Makeup mirror"
+          },
+          {
+            "value": "240",
+            "label": "Upgraded amenities"
+          },
+          {
+            "value": "241",
+            "label": "VCR at front desk"
+          },
+          {
+            "value": "242",
+            "label": "Instant hot water"
+          },
+          {
+            "value": "243",
+            "label": "Outdoor space"
+          },
+          {
+            "value": "244",
+            "label": "Hinoki tub"
+          },
+          {
+            "value": "245",
+            "label": "Private pool"
+          },
+          {
+            "value": "246",
+            "label": "HDTV (32\"+)"
+          },
+          {
+            "value": "247",
+            "label": "Windows open"
+          },
+          {
+            "value": "248",
+            "label": "Unspecified bedding"
+          },
+          {
+            "value": "249",
+            "label": "Full bed"
+          },
+          {
+            "value": "250",
+            "label": "Round bed"
+          },
+          {
+            "value": "251",
+            "label": "TV"
+          },
+          {
+            "value": "252",
+            "label": "Child rollaway"
+          },
+          {
+            "value": "253",
+            "label": "DVD at front desk"
+          },
+          {
+            "value": "254",
+            "label": "Video game console"
+          },
+          {
+            "value": "255",
+            "label": "Games at front desk"
+          },
+          {
+            "value": "256",
+            "label": "Dining seats"
+          },
+          {
+            "value": "257",
+            "label": "Full mirror"
+          },
+          {
+            "value": "258",
+            "label": "Cell phones"
+          },
+          {
+            "value": "259",
+            "label": "Movies"
+          },
+          {
+            "value": "260",
+            "label": "Multiple closets"
+          },
+          {
+            "value": "261",
+            "label": "Plates/glassware"
+          },
+          {
+            "value": "262",
+            "label": "Laptop-safe"
+          },
+          {
+            "value": "263",
+            "label": "Thread count"
+          },
+          {
+            "value": "264",
+            "label": "Blackout curtains"
+          },
+          {
+            "value": "265",
+            "label": "Blu-ray"
+          },
+          {
+            "value": "266",
+            "label": "MP3 device"
+          },
+          {
+            "value": "267",
+            "label": "No adult channels"
+          },
+          {
+            "value": "268",
+            "label": "Non-allergenic room"
+          },
+          {
+            "value": "269",
+            "label": "Pillow type"
+          },
+          {
+            "value": "270",
+            "label": "Seating with sofa"
+          },
+          {
+            "value": "271",
+            "label": "Separate toilet"
+          },
+          {
+            "value": "272",
+            "label": "Web enabled"
+          },
+          {
+            "value": "273",
+            "label": "Widescreen TV"
+          },
+          {
+            "value": "274",
+            "label": "Other connection"
+          },
+          {
+            "value": "275",
+            "label": "Phone billed separately"
+          },
+          {
+            "value": "276",
+            "label": "Separate tub/shower"
+          },
+          {
+            "value": "277",
+            "label": "Video games"
+          },
+          {
+            "value": "278",
+            "label": "Roof ventilator"
+          },
+          {
+            "value": "279",
+            "label": "Playpen"
+          },
+          {
+            "value": "280",
+            "label": "Plunge pool"
+          },
+          {
+            "value": "281",
+            "label": "DVD movies"
+          },
+          {
+            "value": "282",
+            "label": "Air filtration"
+          },
+          {
+            "value": "283",
+            "label": "In-room exercise"
+          },
+          {
+            "value": "284",
+            "label": "Wrapped coffee/condiments"
+          },
+          {
+            "value": "285",
+            "label": "Disinfected remotes"
+          },
+          {
+            "value": "286",
+            "label": "Amenities removed"
+          },
+          {
+            "value": "287",
+            "label": "Mobile device controls"
+          },
+          {
+            "value": "288",
+            "label": "TV via mobile"
+          },
+          {
+            "value": "289",
+            "label": "Voice room controls"
+          },
+          {
+            "value": "290",
+            "label": "Room air purifier"
+          },
+          {
+            "value": "291",
+            "label": "Allergy-friendly room"
+          },
+          {
+            "value": "292",
+            "label": "Medical-grade purifier"
+          },
+          {
+            "value": "293",
+            "label": "Sanitized surfaces"
+          }
+        ]
+      },
+      {
+        "code": "RSI",
+        "label": "Restaurant service info codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Buffet"
+          },
+          {
+            "value": "2",
+            "label": "Casual dining"
+          },
+          {
+            "value": "3",
+            "label": "Catering"
+          },
+          {
+            "value": "4",
+            "label": "Cooked to order"
+          },
+          {
+            "value": "5",
+            "label": "Fine dining"
+          },
+          {
+            "value": "6",
+            "label": "Full service"
+          },
+          {
+            "value": "7",
+            "label": "Meals to go"
+          },
+          {
+            "value": "8",
+            "label": "Room service"
+          },
+          {
+            "value": "9",
+            "label": "Self service"
+          },
+          {
+            "value": "10",
+            "label": "Special meal services"
+          },
+          {
+            "value": "11",
+            "label": "Take out"
+          },
+          {
+            "value": "12",
+            "label": "Delivery service to property available"
+          },
+          {
+            "value": "13",
+            "label": "Children's menu available"
+          },
+          {
+            "value": "14",
+            "label": "Dedicated non-smoking section"
+          },
+          {
+            "value": "15",
+            "label": "Smoking section available"
+          },
+          {
+            "value": "16",
+            "label": "Accommodates diabetic/sugar free requirements"
+          },
+          {
+            "value": "17",
+            "label": "Accommodates gluten free requirements"
+          },
+          {
+            "value": "18",
+            "label": "Accommodates lactose free requirements"
+          },
+          {
+            "value": "19",
+            "label": "Accommodates low fat requirements"
+          },
+          {
+            "value": "20",
+            "label": "Accommodates high fiber requirements"
+          },
+          {
+            "value": "21",
+            "label": "Accommodates low potassium requirements"
+          },
+          {
+            "value": "22",
+            "label": "Accommodates low sodium requirements"
+          }
+        ]
+      },
+      {
+        "code": "RST",
+        "label": "Recreation service types",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Archery"
+          },
+          {
+            "value": "2",
+            "label": "Badminton court"
+          },
+          {
+            "value": "3",
+            "label": "Baseball diamond"
+          },
+          {
+            "value": "4",
+            "label": "Basketball court"
+          },
+          {
+            "value": "5",
+            "label": "Beach"
+          },
+          {
+            "value": "6",
+            "label": "Bike trail"
+          },
+          {
+            "value": "7",
+            "label": "Boating"
+          },
+          {
+            "value": "8",
+            "label": "Bocce court"
+          },
+          {
+            "value": "9",
+            "label": "Bowling alley"
+          },
+          {
+            "value": "10",
+            "label": "Children's program"
+          },
+          {
+            "value": "12",
+            "label": "Cricket pitch"
+          },
+          {
+            "value": "13",
+            "label": "Cross country skiing"
+          },
+          {
+            "value": "14",
+            "label": "Dart board"
+          },
+          {
+            "value": "18",
+            "label": "Downhill skiing"
+          },
+          {
+            "value": "20",
+            "label": "Fishing"
+          },
+          {
+            "value": "25",
+            "label": "Fly fishing"
+          },
+          {
+            "value": "26",
+            "label": "Football field"
+          },
+          {
+            "value": "27",
+            "label": "Golf"
+          },
+          {
+            "value": "35",
+            "label": "Fitness center"
+          },
+          {
+            "value": "36",
+            "label": "Health club"
+          },
+          {
+            "value": "60",
+            "label": "Hiking trail"
+          },
+          {
+            "value": "61",
+            "label": "Horseback riding"
+          },
+          {
+            "value": "62",
+            "label": "Indoor tennis courts"
+          },
+          {
+            "value": "63",
+            "label": "Jet-ski"
+          },
+          {
+            "value": "64",
+            "label": "Jogging trail"
+          },
+          {
+            "value": "65",
+            "label": "Kayaking"
+          },
+          {
+            "value": "66",
+            "label": "Lake"
+          },
+          {
+            "value": "67",
+            "label": "Miniature golf"
+          },
+          {
+            "value": "68",
+            "label": "Mountain biking trail"
+          },
+          {
+            "value": "70",
+            "label": "Ocean"
+          },
+          {
+            "value": "71",
+            "label": "Outdoor tennis courts"
+          },
+          {
+            "value": "73",
+            "label": "Para-sailing"
+          },
+          {
+            "value": "74",
+            "label": "Playground"
+          },
+          {
+            "value": "75",
+            "label": "Pool"
+          },
+          {
+            "value": "76",
+            "label": "Putt putt golf"
+          },
+          {
+            "value": "77",
+            "label": "Racquetball court"
+          },
+          {
+            "value": "78",
+            "label": "River"
+          },
+          {
+            "value": "79",
+            "label": "River rafting"
+          },
+          {
+            "value": "80",
+            "label": "Sailing"
+          },
+          {
+            "value": "81",
+            "label": "Sauna"
+          },
+          {
+            "value": "82",
+            "label": "Scuba diving"
+          },
+          {
+            "value": "83",
+            "label": "Shopping"
+          },
+          {
+            "value": "84",
+            "label": "Skating rink"
+          },
+          {
+            "value": "85",
+            "label": "Skeet shooting"
+          },
+          {
+            "value": "86",
+            "label": "Snorkeling"
+          },
+          {
+            "value": "87",
+            "label": "Snow boarding"
+          },
+          {
+            "value": "88",
+            "label": "Snow skiing"
+          },
+          {
+            "value": "89",
+            "label": "Soccer field"
+          },
+          {
+            "value": "90",
+            "label": "Solarium"
+          },
+          {
+            "value": "91",
+            "label": "Spa facility"
+          },
+          {
+            "value": "92",
+            "label": "Squash court"
+          },
+          {
+            "value": "93",
+            "label": "Steam bath"
+          },
+          {
+            "value": "94",
+            "label": "Tennis court"
+          },
+          {
+            "value": "96",
+            "label": "Tubing"
+          },
+          {
+            "value": "97",
+            "label": "Velodrome"
+          },
+          {
+            "value": "98",
+            "label": "Volleyball"
+          },
+          {
+            "value": "99",
+            "label": "Water-skiing"
+          },
+          {
+            "value": "100",
+            "label": "Whirlpool"
+          },
+          {
+            "value": "101",
+            "label": "Windsurfing"
+          },
+          {
+            "value": "102",
+            "label": "Driving range"
+          },
+          {
+            "value": "103",
+            "label": "Camping"
+          },
+          {
+            "value": "104",
+            "label": "Hot tub"
+          },
+          {
+            "value": "105",
+            "label": "Hunting"
+          },
+          {
+            "value": "106",
+            "label": "Indoor / Outdoor connecting pool"
+          },
+          {
+            "value": "108",
+            "label": "Mountain climbing"
+          },
+          {
+            "value": "109",
+            "label": "Nature preserve trail"
+          },
+          {
+            "value": "110",
+            "label": "Water activities"
+          },
+          {
+            "value": "111",
+            "label": "Billiards"
+          },
+          {
+            "value": "112",
+            "label": "Rock climbing"
+          },
+          {
+            "value": "113",
+            "label": "Safari"
+          },
+          {
+            "value": "114",
+            "label": "Sports court "
+          },
+          {
+            "value": "115",
+            "label": "Sun tanning bed"
+          },
+          {
+            "value": "116",
+            "label": "Surfing"
+          },
+          {
+            "value": "117",
+            "label": "Table tennis"
+          },
+          {
+            "value": "118",
+            "label": "Wine tasting"
+          },
+          {
+            "value": "119",
+            "label": "Winter sports"
+          },
+          {
+            "value": "120",
+            "label": "Snow mobiling"
+          },
+          {
+            "value": "121",
+            "label": "Teen programs"
+          },
+          {
+            "value": "122",
+            "label": "Indoor pool"
+          },
+          {
+            "value": "123",
+            "label": "Outdoor pool"
+          },
+          {
+            "value": "125",
+            "label": "Children's program"
+          },
+          {
+            "value": "126",
+            "label": "Animal watching"
+          },
+          {
+            "value": "127",
+            "label": "Bird watching"
+          },
+          {
+            "value": "128",
+            "label": "Boxing"
+          },
+          {
+            "value": "129",
+            "label": "Children's pool"
+          },
+          {
+            "value": "130",
+            "label": "Dancing"
+          },
+          {
+            "value": "131",
+            "label": "Dog racing"
+          },
+          {
+            "value": "133",
+            "label": "Gambling"
+          },
+          {
+            "value": "134",
+            "label": "Garden"
+          },
+          {
+            "value": "135",
+            "label": "Helicopter / Airplane sightseeing"
+          },
+          {
+            "value": "136",
+            "label": "Horse racing"
+          },
+          {
+            "value": "137",
+            "label": "Ice skating"
+          },
+          {
+            "value": "138",
+            "label": "Karaoke"
+          },
+          {
+            "value": "139",
+            "label": "Museum / Gallery"
+          },
+          {
+            "value": "140",
+            "label": "Nightclub"
+          },
+          {
+            "value": "141",
+            "label": "Polo"
+          },
+          {
+            "value": "142",
+            "label": "Sightseeing tours"
+          },
+          {
+            "value": "143",
+            "label": "Sports events"
+          },
+          {
+            "value": "144",
+            "label": "Skydiving"
+          },
+          {
+            "value": "145",
+            "label": "Sunbathing"
+          },
+          {
+            "value": "146",
+            "label": "Theatre"
+          },
+          {
+            "value": "147",
+            "label": "Weightlifting"
+          },
+          {
+            "value": "148",
+            "label": "Wrestling"
+          },
+          {
+            "value": "149",
+            "label": "Canoeing"
+          },
+          {
+            "value": "150",
+            "label": "Upscale shopping"
+          },
+          {
+            "value": "151",
+            "label": "Outlet shopping"
+          },
+          {
+            "value": "152",
+            "label": "Antique shopping"
+          },
+          {
+            "value": "157",
+            "label": "Tennis professional"
+          },
+          {
+            "value": "158",
+            "label": "Extensive health club"
+          },
+          {
+            "value": "159",
+            "label": "Limited health club"
+          },
+          {
+            "value": "160",
+            "label": "Diving"
+          },
+          {
+            "value": "161",
+            "label": "Walking track"
+          },
+          {
+            "value": "162",
+            "label": "Bike rental"
+          },
+          {
+            "value": "163",
+            "label": "Paddle court"
+          },
+          {
+            "value": "164",
+            "label": "Boat tours"
+          },
+          {
+            "value": "165",
+            "label": "Kids golf academy"
+          },
+          {
+            "value": "166",
+            "label": "Kids beach club"
+          },
+          {
+            "value": "167",
+            "label": "Kids equestrian club"
+          },
+          {
+            "value": "168",
+            "label": "Massage services"
+          }
+        ]
+      },
+      {
+        "code": "RVT",
+        "label": "Room type view codes",
+        "codes": [
+          {
+            "value": "0",
+            "label": "No view"
+          },
+          {
+            "value": "1",
+            "label": "Airport view"
+          },
+          {
+            "value": "2",
+            "label": "Bay view"
+          },
+          {
+            "value": "3",
+            "label": "City view"
+          },
+          {
+            "value": "4",
+            "label": "Courtyard view"
+          },
+          {
+            "value": "5",
+            "label": "Golf view"
+          },
+          {
+            "value": "6",
+            "label": "Harbor view"
+          },
+          {
+            "value": "7",
+            "label": "Intercoastal view"
+          },
+          {
+            "value": "8",
+            "label": "Lake view"
+          },
+          {
+            "value": "9",
+            "label": "Marina view"
+          },
+          {
+            "value": "10",
+            "label": "Mountain view"
+          },
+          {
+            "value": "11",
+            "label": "Ocean view"
+          },
+          {
+            "value": "12",
+            "label": "Pool view"
+          },
+          {
+            "value": "13",
+            "label": "River view"
+          },
+          {
+            "value": "14",
+            "label": "Water view"
+          },
+          {
+            "value": "15",
+            "label": "Beach view"
+          },
+          {
+            "value": "16",
+            "label": "Garden view"
+          },
+          {
+            "value": "17",
+            "label": "Park view"
+          },
+          {
+            "value": "18",
+            "label": "Forest view"
+          },
+          {
+            "value": "19",
+            "label": "Rain forest view"
+          },
+          {
+            "value": "20",
+            "label": "Various views"
+          },
+          {
+            "value": "21",
+            "label": "Limited view"
+          },
+          {
+            "value": "22",
+            "label": "Slope view"
+          },
+          {
+            "value": "23",
+            "label": "Strip view"
+          },
+          {
+            "value": "24",
+            "label": "Countryside view"
+          },
+          {
+            "value": "25",
+            "label": "Sea view"
+          },
+          {
+            "value": "26",
+            "label": "Gulf view"
+          }
+        ]
+      },
+      {
+        "code": "SEC",
+        "label": "Security feature codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "2nd lock on guest doors"
+          },
+          {
+            "value": "2",
+            "label": "Address of nearest police station"
+          },
+          {
+            "value": "3",
+            "label": "Alarms continuously monitored"
+          },
+          {
+            "value": "4",
+            "label": "Audible alarm smoke detectors in guest rooms"
+          },
+          {
+            "value": "5",
+            "label": "Auto link to fire station"
+          },
+          {
+            "value": "6",
+            "label": "Automatic fire doors"
+          },
+          {
+            "value": "7",
+            "label": "Building meets all current local, state and country building codes"
+          },
+          {
+            "value": "8",
+            "label": "Complies with Hotel/Motel Safety Act"
+          },
+          {
+            "value": "9",
+            "label": "Complies with Local/State/Federal fire laws"
+          },
+          {
+            "value": "10",
+            "label": "Dead bolts on guest room doors"
+          },
+          {
+            "value": "11",
+            "label": "Distance to nearest police station"
+          },
+          {
+            "value": "12",
+            "label": "Doctor on call"
+          },
+          {
+            "value": "13",
+            "label": "Electronic room key"
+          },
+          {
+            "value": "14",
+            "label": "Elevator auto recall"
+          },
+          {
+            "value": "15",
+            "label": "Emergency back-up generators"
+          },
+          {
+            "value": "16",
+            "label": "Emergency evacuation plan"
+          },
+          {
+            "value": "17",
+            "label": "Emergency exit maps"
+          },
+          {
+            "value": "18",
+            "label": "Emergency info in room"
+          },
+          {
+            "value": "19",
+            "label": "Emergency lighting"
+          },
+          {
+            "value": "20",
+            "label": "Fire detectors in guest rooms"
+          },
+          {
+            "value": "21",
+            "label": "Fire detectors in hallways"
+          },
+          {
+            "value": "22",
+            "label": "Fire detectors in public areas"
+          },
+          {
+            "value": "23",
+            "label": "Fire extinguishers"
+          },
+          {
+            "value": "24",
+            "label": "Fire resistant guest room doors"
+          },
+          {
+            "value": "25",
+            "label": "Fire resistant hall room doors"
+          },
+          {
+            "value": "26",
+            "label": "Frequency of evacuation drills"
+          },
+          {
+            "value": "27",
+            "label": "Guest room doors self-closing"
+          },
+          {
+            "value": "28",
+            "label": "Hard wired smoke detectors"
+          },
+          {
+            "value": "29",
+            "label": "If no 24 hour security, what are the hours?"
+          },
+          {
+            "value": "30",
+            "label": "Lighted parking area"
+          },
+          {
+            "value": "31",
+            "label": "Lighted walkways"
+          },
+          {
+            "value": "32",
+            "label": "Multiple exits on each floor"
+          },
+          {
+            "value": "33",
+            "label": "Parking area attendants"
+          },
+          {
+            "value": "34",
+            "label": "Patrolled parking area"
+          },
+          {
+            "value": "35",
+            "label": "Phone number of nearest police station"
+          },
+          {
+            "value": "36",
+            "label": "Property has elevators"
+          },
+          {
+            "value": "37",
+            "label": "Public address system"
+          },
+          {
+            "value": "38",
+            "label": "Response time (minutes) from fire/police department"
+          },
+          {
+            "value": "39",
+            "label": "Restricted public access"
+          },
+          {
+            "value": "40",
+            "label": "Room access through exterior corridor"
+          },
+          {
+            "value": "41",
+            "label": "Room access through interior corridor"
+          },
+          {
+            "value": "42",
+            "label": "Room accessible through balcony sliding glass doors"
+          },
+          {
+            "value": "43",
+            "label": "Room windows open"
+          },
+          {
+            "value": "44",
+            "label": "Safety chains on guest doors"
+          },
+          {
+            "value": "45",
+            "label": "Secondary locks on room windows"
+          },
+          {
+            "value": "46",
+            "label": "Secondary locks on sliding glass doors"
+          },
+          {
+            "value": "47",
+            "label": "Security 24 hours/day"
+          },
+          {
+            "value": "48",
+            "label": "Smoke detector in guest rooms"
+          },
+          {
+            "value": "49",
+            "label": "Smoke detector in hallways"
+          },
+          {
+            "value": "50",
+            "label": "Smoke detector in public areas"
+          },
+          {
+            "value": "51",
+            "label": "Some guest rooms have a balcony"
+          },
+          {
+            "value": "52",
+            "label": "Sprinklers in guest rooms"
+          },
+          {
+            "value": "53",
+            "label": "Sprinklers in hallways"
+          },
+          {
+            "value": "54",
+            "label": "Sprinklers in public areas"
+          },
+          {
+            "value": "55",
+            "label": "Staff trained in CPR"
+          },
+          {
+            "value": "56",
+            "label": "Staff trained in duplicate key issue"
+          },
+          {
+            "value": "57",
+            "label": "Staff trained in first aid"
+          },
+          {
+            "value": "58",
+            "label": "Uniformed security"
+          },
+          {
+            "value": "59",
+            "label": "Ventilated stair wells"
+          },
+          {
+            "value": "60",
+            "label": "Video cameras at entrance"
+          },
+          {
+            "value": "61",
+            "label": "Video cameras in hallways"
+          },
+          {
+            "value": "62",
+            "label": "Video cameras in public areas"
+          },
+          {
+            "value": "63",
+            "label": "Viewports in guest room doors"
+          },
+          {
+            "value": "64",
+            "label": "Visual alarm in guest rooms"
+          },
+          {
+            "value": "65",
+            "label": "Well lighted exit signs"
+          },
+          {
+            "value": "66",
+            "label": "Which floors have exterior entrances"
+          },
+          {
+            "value": "67",
+            "label": "Which floors have interior entrances"
+          },
+          {
+            "value": "68",
+            "label": "Balcony accessibly by adjoining rooms"
+          },
+          {
+            "value": "69",
+            "label": "Double glazed windows"
+          },
+          {
+            "value": "70",
+            "label": "Fire extinguishers in hallways"
+          },
+          {
+            "value": "71",
+            "label": "Security "
+          },
+          {
+            "value": "72",
+            "label": "Audible alarms in hallways"
+          },
+          {
+            "value": "73",
+            "label": "Audible alarms in public areas"
+          },
+          {
+            "value": "74",
+            "label": "Automated External Defibrillator (AED) on-site"
+          },
+          {
+            "value": "75",
+            "label": "Basic medical equipment on-site"
+          },
+          {
+            "value": "76",
+            "label": "Camera monitoring parking area 24 hrs"
+          },
+          {
+            "value": "77",
+            "label": "Camera recording parking area 24 hrs"
+          },
+          {
+            "value": "78",
+            "label": "Controlled access to parking"
+          },
+          {
+            "value": "79",
+            "label": "Exterior doors (except lobby entrance) require key access at night"
+          },
+          {
+            "value": "80",
+            "label": "Staff Red Cross certified in CPR"
+          },
+          {
+            "value": "81",
+            "label": "Staff trained in Automated External Defibrillator (AED) usage"
+          },
+          {
+            "value": "82",
+            "label": "Video surveillance of parking"
+          },
+          {
+            "value": "83",
+            "label": "Visual alarms in hallways"
+          },
+          {
+            "value": "84",
+            "label": "Visual alarms in public areas"
+          },
+          {
+            "value": "85",
+            "label": "Emergency exits on each floor"
+          },
+          {
+            "value": "86",
+            "label": "Video surveillance recorded 24 hrs a day"
+          },
+          {
+            "value": "87",
+            "label": "Video surveillance monitored 24 hrs a day"
+          },
+          {
+            "value": "88",
+            "label": "Carbon monoxide detector"
+          },
+          {
+            "value": "89",
+            "label": "Fire extinguishers in public areas"
+          },
+          {
+            "value": "90",
+            "label": "First aid available"
+          },
+          {
+            "value": "91",
+            "label": "Private security available"
+          },
+          {
+            "value": "92",
+            "label": "Secured floors"
+          },
+          {
+            "value": "93",
+            "label": "U.S. Fire Safety compliant"
+          },
+          {
+            "value": "94",
+            "label": "Evacuation drills"
+          },
+          {
+            "value": "95",
+            "label": "Hotel has fire safety measures in place but does not meet a national fire safety standard"
+          },
+          {
+            "value": "96",
+            "label": "FEMA approved"
+          },
+          {
+            "value": "97",
+            "label": "Hours security"
+          },
+          {
+            "value": "98",
+            "label": "Emergency svc response time (minutes)"
+          },
+          {
+            "value": "99",
+            "label": "Security escorts available on request"
+          },
+          {
+            "value": "100",
+            "label": "Swingbolt lock"
+          },
+          {
+            "value": "101",
+            "label": "AAA security standards"
+          },
+          {
+            "value": "102",
+            "label": "Connecting doors have deadbolts"
+          },
+          {
+            "value": "103",
+            "label": "Emergency call button on phone"
+          },
+          {
+            "value": "104",
+            "label": "Audible alarms"
+          },
+          {
+            "value": "105",
+            "label": "A floor only accessible via a guest room key "
+          },
+          {
+            "value": "106",
+            "label": "Health club facilities (pool/gym) require key access for entrance "
+          },
+          {
+            "value": "107",
+            "label": "VIP Security"
+          }
+        ]
+      },
+      {
+        "code": "SEG",
+        "label": "Segment codes",
+        "codes": [
+          {
+            "value": "2",
+            "label": "Budget"
+          },
+          {
+            "value": "4",
+            "label": "Deluxe"
+          },
+          {
+            "value": "5",
+            "label": "Economy"
+          },
+          {
+            "value": "7",
+            "label": "First class"
+          },
+          {
+            "value": "8",
+            "label": "Luxury"
+          },
+          {
+            "value": "10",
+            "label": "Moderate"
+          },
+          {
+            "value": "13",
+            "label": "Tourist"
+          },
+          {
+            "value": "14",
+            "label": "Upscale"
+          },
+          {
+            "value": "15",
+            "label": "Upscale"
+          },
+          {
+            "value": "16",
+            "label": "Standard"
+          },
+          {
+            "value": "17",
+            "label": "Mid-scale"
+          }
+        ]
+      },
+      {
+        "code": "SPA",
+        "label": "Spa feature codes",
+        "codes": [
+          {
+            "value": "1",
+            "label": "Hammam"
+          },
+          {
+            "value": "2",
+            "label": "Sauna"
+          },
+          {
+            "value": "3",
+            "label": "Jacuzzi"
+          },
+          {
+            "value": "4",
+            "label": "Couple treatment room"
+          },
+          {
+            "value": "5",
+            "label": "Outdoor treatment room"
+          },
+          {
+            "value": "6",
+            "label": "Indoor Pool"
+          },
+          {
+            "value": "7",
+            "label": "Outdoor Pool"
+          },
+          {
+            "value": "8",
+            "label": "Relaxation area"
+          },
+          {
+            "value": "9",
+            "label": "Steam Room"
+          },
+          {
+            "value": "10",
+            "label": "Locker room "
+          },
+          {
+            "value": "11",
+            "label": "Changing room"
+          },
+          {
+            "value": "12",
+            "label": "Private Spa suite"
+          },
+          {
+            "value": "13",
+            "label": "Onsen"
+          },
+          {
+            "value": "14",
+            "label": "Natural Hotspring"
+          },
+          {
+            "value": "15",
+            "label": "Juice Bar"
+          },
+          {
+            "value": "16",
+            "label": "Spa product retail shop"
+          },
+          {
+            "value": "17",
+            "label": "Qi Gong"
+          },
+          {
+            "value": "18",
+            "label": "Tai Chi"
+          },
+          {
+            "value": "19",
+            "label": "Reiki"
+          },
+          {
+            "value": "20",
+            "label": "Aromatherapy"
+          },
+          {
+            "value": "21",
+            "label": "Acupuncture"
+          },
+          {
+            "value": "22",
+            "label": "Chiropractic"
+          },
+          {
+            "value": "23",
+            "label": "Naturopathy"
+          },
+          {
+            "value": "24",
+            "label": "Chromotherapy"
+          },
+          {
+            "value": "25",
+            "label": "Hydrotherapy"
+          },
+          {
+            "value": "26",
+            "label": "Crystal Therapy"
+          },
+          {
+            "value": "27",
+            "label": "Cryotherapy"
+          },
+          {
+            "value": "28",
+            "label": "Fitness "
+          },
+          {
+            "value": "29",
+            "label": "Yoga studio"
+          },
+          {
+            "value": "30",
+            "label": "Pilates"
+          },
+          {
+            "value": "31",
+            "label": "Detox Program"
+          },
+          {
+            "value": "32",
+            "label": "Watsu Pool"
+          },
+          {
+            "value": "33",
+            "label": "Meditation"
+          },
+          {
+            "value": "34",
+            "label": "Weight Loss Program"
+          },
+          {
+            "value": "35",
+            "label": "Weight Management Program"
+          },
+          {
+            "value": "36",
+            "label": "Stress Management Program"
+          },
+          {
+            "value": "37",
+            "label": "Spinning"
+          },
+          {
+            "value": "38",
+            "label": "Personal Trainer"
+          },
+          {
+            "value": "39",
+            "label": "Boot Camp"
+          },
+          {
+            "value": "40",
+            "label": "Nutritionist available"
+          },
+          {
+            "value": "41",
+            "label": "Colon Hydrotherapy"
+          },
+          {
+            "value": "42",
+            "label": "Restaurant offering Spa Cuisine"
+          },
+          {
+            "value": "43",
+            "label": "Physiotherapy"
+          },
+          {
+            "value": "44",
+            "label": "Food Supplement"
+          },
+          {
+            "value": "45",
+            "label": "Aerobics"
+          },
+          {
+            "value": "46",
+            "label": "Nail salon"
+          },
+          {
+            "value": "47",
+            "label": "Make up services"
+          },
+          {
+            "value": "48",
+            "label": "Hair salon"
+          },
+          {
+            "value": "49",
+            "label": "Pregnancy massage"
+          },
+          {
+            "value": "50",
+            "label": "Manicure & Pedicure"
+          },
+          {
+            "value": "51",
+            "label": "Botox"
+          },
+          {
+            "value": "52",
+            "label": "Ayurvedic Treatment"
+          },
+          {
+            "value": "53",
+            "label": "Reflexology"
+          },
+          {
+            "value": "54",
+            "label": "Waxing"
+          },
+          {
+            "value": "55",
+            "label": "Facial"
+          },
+          {
+            "value": "56",
+            "label": "Anti Aging Treatment"
+          },
+          {
+            "value": "57",
+            "label": "Laser Hair Removal"
+          },
+          {
+            "value": "58",
+            "label": "Body Scrub"
+          },
+          {
+            "value": "59",
+            "label": "Vichy Shower"
+          },
+          {
+            "value": "60",
+            "label": "Massage"
+          },
+          {
+            "value": "61",
+            "label": "Deep Tissue massage"
+          },
+          {
+            "value": "62",
+            "label": "Hot Stone Massage"
+          },
+          {
+            "value": "63",
+            "label": "Thai Massage"
+          },
+          {
+            "value": "64",
+            "label": "Swedish Massage"
+          },
+          {
+            "value": "65",
+            "label": "Foot Reflexology"
+          },
+          {
+            "value": "66",
+            "label": "Hawaiian Massage"
+          },
+          {
+            "value": "67",
+            "label": "Doctor on Site"
+          },
+          {
+            "value": "68",
+            "label": "Nurse on Site"
+          },
+          {
+            "value": "69",
+            "label": "Female Therapist only"
+          },
+          {
+            "value": "70",
+            "label": "Male Therapist only"
+          },
+          {
+            "value": "71",
+            "label": "Female and Male therapist"
+          },
+          {
+            "value": "72",
+            "label": "Teens allowed"
+          },
+          {
+            "value": "73",
+            "label": "Fee Wifi"
+          },
+          {
+            "value": "74",
+            "label": "Health consultation"
+          }
+        ]
+      }
+    ]
+  },
+  "languages": {
+    "default": "en",
+    "list": [
+      {
+        "code": "en",
+        "name": "English"
+      },
+      {
+        "code": "id",
+        "name": "Indonesian"
+      },
+      {
+        "code": "ms",
+        "name": "Malay"
+      },
+      {
+        "code": "bg",
+        "name": "Bulgarian"
+      },
+      {
+        "code": "ca",
+        "name": "Catalan"
+      },
+      {
+        "code": "cs",
+        "name": "Czech"
+      },
+      {
+        "code": "da",
+        "name": "Danish"
+      },
+      {
+        "code": "de",
+        "name": "German"
+      },
+      {
+        "code": "et",
+        "name": "Estonian"
+      },
+      {
+        "code": "es",
+        "name": "Spanish"
+      },
+      {
+        "code": "es-AR",
+        "name": "Spanish (Argentina)"
+      },
+      {
+        "code": "es-MX",
+        "name": "Mexican Spanish"
+      },
+      {
+        "code": "tl",
+        "name": "Filipino"
+      },
+      {
+        "code": "fi",
+        "name": "Finnish"
+      },
+      {
+        "code": "fr",
+        "name": "French"
+      },
+      {
+        "code": "el",
+        "name": "Greek"
+      },
+      {
+        "code": "he",
+        "name": "Hebrew"
+      },
+      {
+        "code": "hi",
+        "name": "Hindi"
+      },
+      {
+        "code": "hr",
+        "name": "Croatian"
+      },
+      {
+        "code": "hu",
+        "name": "Hungarian"
+      },
+      {
+        "code": "is",
+        "name": "Icelandic"
+      },
+      {
+        "code": "it",
+        "name": "Italian"
+      },
+      {
+        "code": "ja",
+        "name": "Japanese"
+      },
+      {
+        "code": "ko",
+        "name": "Korean"
+      },
+      {
+        "code": "lv",
+        "name": "Latvian"
+      },
+      {
+        "code": "lt",
+        "name": "Lithuanian"
+      },
+      {
+        "code": "nl",
+        "name": "Dutch"
+      },
+      {
+        "code": "no",
+        "name": "Norwegian"
+      },
+      {
+        "code": "pl",
+        "name": "Polish"
+      },
+      {
+        "code": "pt-BR",
+        "name": "Brazilian Portuguese"
+      },
+      {
+        "code": "pt-PT",
+        "name": "European Portuguese"
+      },
+      {
+        "code": "ro",
+        "name": "Romanian"
+      },
+      {
+        "code": "ru",
+        "name": "Russian"
+      },
+      {
+        "code": "sk",
+        "name": "Slovak"
+      },
+      {
+        "code": "sl",
+        "name": "Slovenian"
+      },
+      {
+        "code": "sr",
+        "name": "Serbian"
+      },
+      {
+        "code": "sv",
+        "name": "Swedish"
+      },
+      {
+        "code": "th",
+        "name": "Thai"
+      },
+      {
+        "code": "tr",
+        "name": "Turkish"
+      },
+      {
+        "code": "uk",
+        "name": "Ukrainian"
+      },
+      {
+        "code": "vi",
+        "name": "Vietnamese"
+      },
+      {
+        "code": "ar",
+        "name": "Arabic"
+      },
+      {
+        "code": "zh-CN",
+        "name": "Chinese (China)"
+      },
+      {
+        "code": "zh-TW",
+        "name": "Chinese (Taiwan)"
+      }
+    ]
+  },
+  "currencies": {
+    "default": "USD",
+    "list": [
+      {
+        "code": "AED",
+        "name": "United Arab Emirates Dirham"
+      },
+      {
+        "code": "AFN",
+        "name": "Afghan Afghani"
+      },
+      {
+        "code": "ALL",
+        "name": "Albanian Lek"
+      },
+      {
+        "code": "AMD",
+        "name": "Armenian Dram"
+      },
+      {
+        "code": "ANG",
+        "name": "Netherlands Antillean Guilder"
+      },
+      {
+        "code": "AOA",
+        "name": "Angolan Kwanza"
+      },
+      {
+        "code": "ARS",
+        "name": "Argentine Peso"
+      },
+      {
+        "code": "AUD",
+        "name": "Australian Dollar"
+      },
+      {
+        "code": "AWG",
+        "name": "Aruban Florin"
+      },
+      {
+        "code": "AZN",
+        "name": "Azerbaijani Manat"
+      },
+      {
+        "code": "BAM",
+        "name": "Bosnia-Herzegovina Convertible Mark"
+      },
+      {
+        "code": "BBD",
+        "name": "Barbadian Dollar"
+      },
+      {
+        "code": "BDT",
+        "name": "Bangladeshi Taka"
+      },
+      {
+        "code": "BGN",
+        "name": "Bulgarian Lev"
+      },
+      {
+        "code": "BHD",
+        "name": "Bahraini Dinar"
+      },
+      {
+        "code": "BIF",
+        "name": "Burundian Franc"
+      },
+      {
+        "code": "BMD",
+        "name": "Bermudan Dollar"
+      },
+      {
+        "code": "BND",
+        "name": "Brunei Dollar"
+      },
+      {
+        "code": "BOB",
+        "name": "Bolivian Boliviano"
+      },
+      {
+        "code": "BRL",
+        "name": "Brazilian Real"
+      },
+      {
+        "code": "BSD",
+        "name": "Bahamian Dollar"
+      },
+      {
+        "code": "BTC",
+        "name": null
+      },
+      {
+        "code": "BTN",
+        "name": "Bhutanese Ngultrum"
+      },
+      {
+        "code": "BWP",
+        "name": "Botswanan Pula"
+      },
+      {
+        "code": "BYR",
+        "name": "Belarusian Ruble (2000–2016)"
+      },
+      {
+        "code": "BZD",
+        "name": "Belize Dollar"
+      },
+      {
+        "code": "CAD",
+        "name": "Canadian Dollar"
+      },
+      {
+        "code": "CDF",
+        "name": "Congolese Franc"
+      },
+      {
+        "code": "CHF",
+        "name": "Swiss Franc"
+      },
+      {
+        "code": "CLF",
+        "name": "Chilean Unit of Account (UF)"
+      },
+      {
+        "code": "CLP",
+        "name": "Chilean Peso"
+      },
+      {
+        "code": "CNY",
+        "name": "Chinese Yuan"
+      },
+      {
+        "code": "COP",
+        "name": "Colombian Peso"
+      },
+      {
+        "code": "CRC",
+        "name": "Costa Rican Colón"
+      },
+      {
+        "code": "CUC",
+        "name": "Cuban Convertible Peso"
+      },
+      {
+        "code": "CUP",
+        "name": "Cuban Peso"
+      },
+      {
+        "code": "CVE",
+        "name": "Cape Verdean Escudo"
+      },
+      {
+        "code": "CZK",
+        "name": "Czech Koruna"
+      },
+      {
+        "code": "DJF",
+        "name": "Djiboutian Franc"
+      },
+      {
+        "code": "DKK",
+        "name": "Danish Krone"
+      },
+      {
+        "code": "DOP",
+        "name": "Dominican Peso"
+      },
+      {
+        "code": "DZD",
+        "name": "Algerian Dinar"
+      },
+      {
+        "code": "EGP",
+        "name": "Egyptian Pound"
+      },
+      {
+        "code": "ERN",
+        "name": "Eritrean Nakfa"
+      },
+      {
+        "code": "ETB",
+        "name": "Ethiopian Birr"
+      },
+      {
+        "code": "EUR",
+        "name": "Euro"
+      },
+      {
+        "code": "FJD",
+        "name": "Fijian Dollar"
+      },
+      {
+        "code": "FKP",
+        "name": "Falkland Islands Pound"
+      },
+      {
+        "code": "GBP",
+        "name": "British Pound"
+      },
+      {
+        "code": "GEL",
+        "name": "Georgian Lari"
+      },
+      {
+        "code": "GGP",
+        "name": null
+      },
+      {
+        "code": "GHS",
+        "name": "Ghanaian Cedi"
+      },
+      {
+        "code": "GIP",
+        "name": "Gibraltar Pound"
+      },
+      {
+        "code": "GMD",
+        "name": "Gambian Dalasi"
+      },
+      {
+        "code": "GNF",
+        "name": "Guinean Franc"
+      },
+      {
+        "code": "GTQ",
+        "name": "Guatemalan Quetzal"
+      },
+      {
+        "code": "GYD",
+        "name": "Guyanaese Dollar"
+      },
+      {
+        "code": "HKD",
+        "name": "Hong Kong Dollar"
+      },
+      {
+        "code": "HNL",
+        "name": "Honduran Lempira"
+      },
+      {
+        "code": "HRK",
+        "name": "Croatian Kuna"
+      },
+      {
+        "code": "HTG",
+        "name": "Haitian Gourde"
+      },
+      {
+        "code": "HUF",
+        "name": "Hungarian Forint"
+      },
+      {
+        "code": "IDR",
+        "name": "Indonesian Rupiah"
+      },
+      {
+        "code": "ILS",
+        "name": "Israeli New Shekel"
+      },
+      {
+        "code": "IMP",
+        "name": null
+      },
+      {
+        "code": "INR",
+        "name": "Indian Rupee"
+      },
+      {
+        "code": "IQD",
+        "name": "Iraqi Dinar"
+      },
+      {
+        "code": "IRR",
+        "name": "Iranian Rial"
+      },
+      {
+        "code": "ISK",
+        "name": "Icelandic Króna"
+      },
+      {
+        "code": "JEP",
+        "name": null
+      },
+      {
+        "code": "JMD",
+        "name": "Jamaican Dollar"
+      },
+      {
+        "code": "JOD",
+        "name": "Jordanian Dinar"
+      },
+      {
+        "code": "JPY",
+        "name": "Japanese Yen"
+      },
+      {
+        "code": "KES",
+        "name": "Kenyan Shilling"
+      },
+      {
+        "code": "KGS",
+        "name": "Kyrgyz Som"
+      },
+      {
+        "code": "KHR",
+        "name": "Cambodian Riel"
+      },
+      {
+        "code": "KMF",
+        "name": "Comorian Franc"
+      },
+      {
+        "code": "KPW",
+        "name": "North Korean Won"
+      },
+      {
+        "code": "KRW",
+        "name": "South Korean Won"
+      },
+      {
+        "code": "KWD",
+        "name": "Kuwaiti Dinar"
+      },
+      {
+        "code": "KYD",
+        "name": "Cayman Islands Dollar"
+      },
+      {
+        "code": "KZT",
+        "name": "Kazakhstani Tenge"
+      },
+      {
+        "code": "LAK",
+        "name": "Laotian Kip"
+      },
+      {
+        "code": "LBP",
+        "name": "Lebanese Pound"
+      },
+      {
+        "code": "LKR",
+        "name": "Sri Lankan Rupee"
+      },
+      {
+        "code": "LRD",
+        "name": "Liberian Dollar"
+      },
+      {
+        "code": "LSL",
+        "name": "Lesotho Loti"
+      },
+      {
+        "code": "LTL",
+        "name": "Lithuanian Litas"
+      },
+      {
+        "code": "LVL",
+        "name": "Latvian Lats"
+      },
+      {
+        "code": "LYD",
+        "name": "Libyan Dinar"
+      },
+      {
+        "code": "MAD",
+        "name": "Moroccan Dirham"
+      },
+      {
+        "code": "MDL",
+        "name": "Moldovan Leu"
+      },
+      {
+        "code": "MGA",
+        "name": "Malagasy Ariary"
+      },
+      {
+        "code": "MKD",
+        "name": "Macedonian Denar"
+      },
+      {
+        "code": "MMK",
+        "name": "Myanmar Kyat"
+      },
+      {
+        "code": "MNT",
+        "name": "Mongolian Tugrik"
+      },
+      {
+        "code": "MOP",
+        "name": "Macanese Pataca"
+      },
+      {
+        "code": "MUR",
+        "name": "Mauritian Rupee"
+      },
+      {
+        "code": "MVR",
+        "name": "Maldivian Rufiyaa"
+      },
+      {
+        "code": "MWK",
+        "name": "Malawian Kwacha"
+      },
+      {
+        "code": "MXN",
+        "name": "Mexican Peso"
+      },
+      {
+        "code": "MYR",
+        "name": "Malaysian Ringgit"
+      },
+      {
+        "code": "MZN",
+        "name": "Mozambican Metical"
+      },
+      {
+        "code": "NAD",
+        "name": "Namibian Dollar"
+      },
+      {
+        "code": "NGN",
+        "name": "Nigerian Naira"
+      },
+      {
+        "code": "NIO",
+        "name": "Nicaraguan Córdoba"
+      },
+      {
+        "code": "NOK",
+        "name": "Norwegian Krone"
+      },
+      {
+        "code": "NPR",
+        "name": "Nepalese Rupee"
+      },
+      {
+        "code": "NZD",
+        "name": "New Zealand Dollar"
+      },
+      {
+        "code": "OMR",
+        "name": "Omani Rial"
+      },
+      {
+        "code": "PAB",
+        "name": "Panamanian Balboa"
+      },
+      {
+        "code": "PEN",
+        "name": "Peruvian Sol"
+      },
+      {
+        "code": "PGK",
+        "name": "Papua New Guinean Kina"
+      },
+      {
+        "code": "PHP",
+        "name": "Philippine Peso"
+      },
+      {
+        "code": "PKR",
+        "name": "Pakistani Rupee"
+      },
+      {
+        "code": "PLN",
+        "name": "Polish Zloty"
+      },
+      {
+        "code": "PYG",
+        "name": "Paraguayan Guarani"
+      },
+      {
+        "code": "QAR",
+        "name": "Qatari Riyal"
+      },
+      {
+        "code": "RON",
+        "name": "Romanian Leu"
+      },
+      {
+        "code": "RSD",
+        "name": "Serbian Dinar"
+      },
+      {
+        "code": "RUB",
+        "name": "Russian Ruble"
+      },
+      {
+        "code": "RWF",
+        "name": "Rwandan Franc"
+      },
+      {
+        "code": "SAR",
+        "name": "Saudi Riyal"
+      },
+      {
+        "code": "SBD",
+        "name": "Solomon Islands Dollar"
+      },
+      {
+        "code": "SCR",
+        "name": "Seychellois Rupee"
+      },
+      {
+        "code": "SDG",
+        "name": "Sudanese Pound"
+      },
+      {
+        "code": "SEK",
+        "name": "Swedish Krona"
+      },
+      {
+        "code": "SGD",
+        "name": "Singapore Dollar"
+      },
+      {
+        "code": "SHP",
+        "name": "St. Helena Pound"
+      },
+      {
+        "code": "SLL",
+        "name": "Sierra Leonean Leone (1964—2022)"
+      },
+      {
+        "code": "SOS",
+        "name": "Somali Shilling"
+      },
+      {
+        "code": "SRD",
+        "name": "Surinamese Dollar"
+      },
+      {
+        "code": "STD",
+        "name": "São Tomé & Príncipe Dobra (1977–2017)"
+      },
+      {
+        "code": "SYP",
+        "name": "Syrian Pound"
+      },
+      {
+        "code": "SZL",
+        "name": "Swazi Lilangeni"
+      },
+      {
+        "code": "THB",
+        "name": "Thai Baht"
+      },
+      {
+        "code": "TJS",
+        "name": "Tajikistani Somoni"
+      },
+      {
+        "code": "TMT",
+        "name": "Turkmenistani Manat"
+      },
+      {
+        "code": "TND",
+        "name": "Tunisian Dinar"
+      },
+      {
+        "code": "TOP",
+        "name": "Tongan Paʻanga"
+      },
+      {
+        "code": "TRY",
+        "name": "Turkish Lira"
+      },
+      {
+        "code": "TTD",
+        "name": "Trinidad & Tobago Dollar"
+      },
+      {
+        "code": "TWD",
+        "name": "New Taiwan Dollar"
+      },
+      {
+        "code": "TZS",
+        "name": "Tanzanian Shilling"
+      },
+      {
+        "code": "UAH",
+        "name": "Ukrainian Hryvnia"
+      },
+      {
+        "code": "UGX",
+        "name": "Ugandan Shilling"
+      },
+      {
+        "code": "USD",
+        "name": "US Dollar"
+      },
+      {
+        "code": "UYU",
+        "name": "Uruguayan Peso"
+      },
+      {
+        "code": "UZS",
+        "name": "Uzbekistani Som"
+      },
+      {
+        "code": "VND",
+        "name": "Vietnamese Dong"
+      },
+      {
+        "code": "VUV",
+        "name": "Vanuatu Vatu"
+      },
+      {
+        "code": "WST",
+        "name": "Samoan Tala"
+      },
+      {
+        "code": "XAF",
+        "name": "Central African CFA Franc"
+      },
+      {
+        "code": "XAG",
+        "name": "Silver"
+      },
+      {
+        "code": "XAU",
+        "name": "Gold"
+      },
+      {
+        "code": "XCD",
+        "name": "East Caribbean Dollar"
+      },
+      {
+        "code": "XDR",
+        "name": "Special Drawing Rights"
+      },
+      {
+        "code": "XOF",
+        "name": "West African CFA Franc"
+      },
+      {
+        "code": "XPF",
+        "name": "CFP Franc"
+      },
+      {
+        "code": "YER",
+        "name": "Yemeni Rial"
+      },
+      {
+        "code": "ZAR",
+        "name": "South African Rand"
+      },
+      {
+        "code": "ZMK",
+        "name": "Zambian Kwacha (1968–2012)"
+      },
+      {
+        "code": "ZMW",
+        "name": "Zambian Kwacha"
+      },
+      {
+        "code": "ZWL",
+        "name": "Zimbabwean Dollar (2009–2024)"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds **Developers > Taxonomy**, the published home for the three controlled vocabularies integrators need:

| vocabulary | size |
|---|---|
| OTA codes | 25 categories / **1,475 codes** |
| Languages | 44 BCP 47 tags |
| Currencies | 164 ISO 4217 codes |

## Why

These were only discoverable by calling the API. Those four endpoints are now deprecated in monorepo-java (`0ae7b5be7e`, sunset **Wed 01 Oct 2026**) and every deprecated response ships:

```
Link: <https://wink.travel/developers/taxonomy>; rel="alternate"
```

**That URL currently 404s.** This PR is what makes it resolve, so it should land before the backend release deploys.

## Design notes

- **Values are hardcoded on purpose.** No sync script, no build-time read of monorepo-java — syncing would point the dependency back at the surface being retired. `src/data/taxonomy.json` is committed, hand-owned data.
- **No timestamp in the data file.** With one, every regeneration would diff even when nothing changed, making "nothing moved" indistinguishable from a real vocabulary change in review.
- **Codes live outside the MDX** so `translate-i18n.ts` cannot reach them. A translated OTA code is a broken one.
- **Component chrome is passed as props from the MDX**, not written inside the `.astro` files — the translation pipeline reads whole MDX files and never opens a component, so a header hardcoded there would stay English in all 40+ locales with nothing to flag it.
- **Currency and language names are English, from Node's CLDR.** The retired currency endpoint returned bare codes with no names, so these are new presentation. `BTC`, `GGP`, `IMP`, `JEP` have no standard name and say so rather than get an invented one. The code is the contract; the name is not.
- OTA categories render as collapsed `<details>` blocks — 1,475 rows is not a page you scroll — which works with no JavaScript, and the category index anchors land on the right section.

## Verified against the built HTML

- All **1,475** OTA labels, **44** language codes, **164** currency codes present
- All 25 category anchors resolve; 1,736 `<tr>` = 25 index + 1,475 codes + 44 + 164 + 28 headers, exact
- `npx astro check` → 0 errors / 0 warnings across 125 files
- Full `npm run build` → exit 0 (16m29s, 52k pages)
- Appears in the Developers sidebar automatically via `autogenerate` — no `astro.config.mjs` change

## Deliberately not in this PR

`schemas/reference.json` is untouched. It documents the four endpoints as non-deprecated, which is correct until the backend release deploys — specs promote on deploy success, not build success. Run `npm run schemas:sync` after that.